### PR TITLE
feat: API 기본 URL을 환경 변수로 변경

### DIFF
--- a/frontend/src/app/attraction/[id]/page.tsx
+++ b/frontend/src/app/attraction/[id]/page.tsx
@@ -54,7 +54,7 @@ export default function AttractionDetail({ params }: AttractionDetailProps) {
     const fetchAttractionDetail = async () => {
       try {
         setLoading(true)
-        const API_BASE_URL = 'http://localhost:8000'
+        const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
         const response = await fetch(`${API_BASE_URL}/api/v1/attractions/attractions/${params.id}`)
         
         if (!response.ok) {

--- a/frontend/src/app/itinerary/[attractionId]/page.tsx
+++ b/frontend/src/app/itinerary/[attractionId]/page.tsx
@@ -105,7 +105,7 @@ export default function ItineraryBuilder({ params }: ItineraryBuilderProps) {
     const fetchAttractionData = async () => {
       try {
         setLoading(true)
-        const API_BASE_URL = 'http://localhost:8000'
+        const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
         
         // 선택된 관광지 정보 가져오기
         const attractionResponse = await fetch(`${API_BASE_URL}/api/v1/attractions/attractions/${params.attractionId}`)

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -165,7 +165,7 @@ export default function MapPage() {
         const placeIds = placesParam.split(',')
         const dayNumbers = dayNumbersParam.split(',').map(Number)
         
-        const API_BASE_URL = 'http://localhost:8000'
+        const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
         const places: SelectedPlace[] = []
         
         for (let i = 0; i < placeIds.length; i++) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -64,7 +64,7 @@ export default function Home() {
     if (!searchQuery.trim()) return
     
     try {
-      const API_BASE_URL = 'http://localhost:8000'
+      const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
       const response = await fetch(`${API_BASE_URL}/api/v1/attractions/search?q=${encodeURIComponent(searchQuery)}`)
       
       if (!response.ok) {

--- a/frontend/src/app/plan/[attractionId]/page.tsx
+++ b/frontend/src/app/plan/[attractionId]/page.tsx
@@ -56,7 +56,7 @@ export default function PlanCalendar({ params }: PlanCalendarProps) {
     const fetchAttractionDetail = async () => {
       try {
         setLoading(true)
-        const API_BASE_URL = 'http://localhost:8000'
+        const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
         const response = await fetch(`${API_BASE_URL}/api/v1/attractions/attractions/${params.attractionId}`)
         
         if (!response.ok) {


### PR DESCRIPTION
- 여러 페이지에서 API 호출 시 기본 URL을 'http://localhost:8000'에서 환경 변수인 NEXT_PUBLIC_API_BASE 또는 '/api/proxy'로 수정하여 유연성 향상