### PR TITLE
feat/ 추천 알고리즘 메인 페이지 반영

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -38,7 +38,8 @@ app = FastAPI(
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
-        "http://localhost:3000", 
+        "http://localhost:3000",
+        "http://localhost:3001",  # Next.js 개발서버 포트 추가
         "http://frontend:3000",
         "https://k8s-witple-witplefr-01ff6c628a-1226095041.ap-northeast-2.elb.amazonaws.com",
         "http://k8s-witple-witplefr-01ff6c628a-1226095041.ap-northeast-2.elb.amazonaws.com"

--- a/backend/routers/recommendations.py
+++ b/backend/routers/recommendations.py
@@ -176,59 +176,43 @@ async def get_mixed_recommendations(
                         place['recommendation_type'] = 'fallback'
                     return fallback_places
                 except:
-                    # 모든 것이 실패하면 더미 데이터 반환
+                    # 모든 것이 실패하면 실제 DB 데이터 반환
                     return [
                         {
-                            "place_id": 1,
-                            "table_name": "fallback",
-                            "name": "서울 경복궁",
-                            "region": "서울",
-                            "description": "대표적인 관광지",
-                            "latitude": 37.5796,
-                            "longitude": 126.9770,
+                            "place_id": 9628,  # 실제 DB에 존재하는 ID
+                            "table_name": "restaurants",
+                            "name": "해운대식당",
+                            "region": "전라남도",
+                            "description": "전라남도 장성군 장성역 인근 한식당",
+                            "latitude": 35.3021,
+                            "longitude": 126.7886,
                             "recommendation_type": "fallback",
                             "similarity_score": 0.5
                         }
                     ]
         else:
-            # 비로그인 상태: 더미 데이터 반환
-            dummy_places = [
-                {
-                    "place_id": 1,
-                    "table_name": "dummy",
-                    "name": "서울 명동",
-                    "region": "서울",
-                    "description": "쇼핑과 맛집의 메카",
-                    "latitude": 37.5636,
-                    "longitude": 126.9827,
-                    "recommendation_type": "popular",
-                    "similarity_score": 0.9
-                },
-                {
-                    "place_id": 2, 
-                    "table_name": "dummy",
-                    "name": "제주 한라산",
-                    "region": "제주",
-                    "description": "제주도의 상징적인 산",
-                    "latitude": 33.3617,
-                    "longitude": 126.5292,
-                    "recommendation_type": "popular",
-                    "similarity_score": 0.85
-                },
-                {
-                    "place_id": 3,
-                    "table_name": "dummy", 
-                    "name": "부산 해운대",
-                    "region": "부산",
-                    "description": "한국 최고의 해수욕장",
-                    "latitude": 35.1595,
-                    "longitude": 129.1604,
-                    "recommendation_type": "popular",
-                    "similarity_score": 0.8
-                }
-            ]
-            
-            return dummy_places[:limit]
+            # 비로그인 상태: 실제 DB에서 인기 장소 데이터 반환
+            try:
+                popular_places = await recommendation_engine.get_fallback_places(limit=limit)
+                for place in popular_places:
+                    place['recommendation_type'] = 'popular'
+                return popular_places
+            except Exception as e:
+                logger.error(f"Error getting popular places for guest: {str(e)}")
+                # 모든 것이 실패하면 더미 데이터 반환 (실제 DB의 place_id 사용)
+                return [
+                    {
+                        "place_id": 9628,  # 실제 DB에 존재하는 ID
+                        "table_name": "restaurants",
+                        "name": "해운대식당",
+                        "region": "전라남도",
+                        "description": "전라남도 장성군 장성역 인근 한식당",
+                        "latitude": 35.3021,
+                        "longitude": 126.7886,
+                        "recommendation_type": "popular",
+                        "similarity_score": 0.8
+                    }
+                ][:limit]
             
     except Exception as e:
         logger.error(f"Error getting mixed recommendations: {str(e)}")

--- a/backend/vectorization.py
+++ b/backend/vectorization.py
@@ -10,6 +10,7 @@ import logging
 from typing import Dict, List, Tuple, Any
 import asyncio
 import asyncpg
+import json
 from dotenv import load_dotenv
 
 # .env 파일 로드
@@ -417,8 +418,11 @@ class RecommendationEngine:
             # 사용자 선호도 벡터 생성
             user_vector = await self._create_user_vector(preferences, actions)
             
-            # 통합 테이블에서 장소 데이터 가져오기 (JOIN 없음)
-            query = "SELECT * FROM place_recommendations"
+            # place_features에서 장소 데이터와 벡터 가져오기 
+            query = """
+                SELECT place_id, table_name, name, region, city, latitude, longitude, vector
+                FROM place_features WHERE vector IS NOT NULL
+            """
             conditions = []
             params = []
             param_count = 0
@@ -434,23 +438,48 @@ class RecommendationEngine:
                 params.append(category)
             
             if conditions:
-                query += " WHERE " + " AND ".join(conditions)
+                query += " AND " + " AND ".join(conditions)
             
             # 성능을 위해 전체가 아닌 샘플링 (큰 데이터셋인 경우)
-            query += " ORDER BY RANDOM() LIMIT 5000"
+            query += " ORDER BY RANDOM() LIMIT 1000"
             
             places = await conn.fetch(query, *params)
             
             if not places:
                 return []
             
-            # 벡터 추출 및 유사도 계산
-            place_vectors = [np.array(place['vector']) for place in places]
+            # 벡터 추출 및 유사도 계산 (JSON 문자열 처리)
+            place_vectors = []
+            valid_places = []
+            
+            for place in places:
+                try:
+                    # 벡터가 JSON 문자열로 저장된 경우 파싱
+                    if isinstance(place['vector'], str):
+                        vector_data = json.loads(place['vector'])
+                    else:
+                        vector_data = place['vector']
+                    
+                    # numpy 배열로 변환
+                    vector_array = np.array(vector_data, dtype=np.float32)
+                    
+                    # 벡터 차원 확인 (256차원이어야 함)
+                    if len(vector_array) == 256:
+                        place_vectors.append(vector_array)
+                        valid_places.append(place)
+                    
+                except (json.JSONDecodeError, ValueError, TypeError) as e:
+                    # 벡터 처리 실패시 해당 장소 제외
+                    continue
+            
+            if not place_vectors:
+                return []
+            
             similarity_scores = self.calculate_similarity_scores(user_vector, place_vectors)
             
             # 점수와 함께 결과 생성
             results = []
-            for i, place in enumerate(places):
+            for i, place in enumerate(valid_places):
                 place_dict = dict(place)
                 place_dict['similarity_score'] = similarity_scores[i]
                 results.append(place_dict)
@@ -508,8 +537,8 @@ class RecommendationEngine:
         all_texts = preference_texts + action_places
         combined_text = ' '.join(all_texts) if all_texts else "일반적인 여행지"
         
-        # BERT 벡터화
-        user_vector = self.bert_model.encode([combined_text])[0]
+        # BERT 벡터화 (256차원으로 자르기 - place_features와 동일하게)
+        user_vector = self.bert_model.encode([combined_text])[0][:256]
         
         return user_vector
 

--- a/frontend/src/app/api/auth/[...nextauth]/route.ts
+++ b/frontend/src/app/api/auth/[...nextauth]/route.ts
@@ -22,6 +22,7 @@ const authOptions: NextAuthOptions = {
 
         try {
           const apiUrl = process.env.API_INTERNAL_URL || process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+          
           const formData = new URLSearchParams()
           formData.append('username', credentials.email)
           formData.append('password', credentials.password)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,10 +3,12 @@
 import React, { useState, FormEvent, useEffect, useCallback, useRef } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { useSession } from 'next-auth/react'
 import { fetchRecommendedCities, type CitySection } from '../lib/dummyData'
 
 export default function Home() {
   const router = useRouter()
+  const { data: session, status } = useSession()
   const [searchQuery, setSearchQuery] = useState('')
   const [citySections, setCitySections] = useState<CitySection[]>([])
   const [loading, setLoading] = useState(false)
@@ -22,7 +24,7 @@ export default function Home() {
     loadingRef.current = true
     setLoading(true)
     try {
-      const { data, hasMore: moreData } = await fetchRecommendedCities(pageNum, 3)
+      const { data, hasMore: moreData } = await fetchRecommendedCities(pageNum, 30)
 
       if (pageNum === 0) {
         setCitySections(data)
@@ -40,10 +42,12 @@ export default function Home() {
     }
   }, [])
 
-  // 초기 데이터 로드
+  // 초기 데이터 로드 (세션이 로드된 후)
   useEffect(() => {
-    loadRecommendedCities(0)
-  }, [])
+    if (status !== 'loading') {
+      loadRecommendedCities(0)
+    }
+  }, [status])
 
   // 무한 스크롤 감지
   const lastElementRef = useCallback((node: HTMLDivElement | null) => {
@@ -117,6 +121,21 @@ export default function Home() {
           </button>
         </form>
       </div>
+
+      {/* 로그인 상태 표시 */}
+      {status !== 'loading' && (
+        <div className="px-4 mb-4 text-center">
+          {session ? (
+            <p className="text-[#3E68FF] text-sm bg-[#12345D]/70 px-4 py-2 rounded-full inline-block">
+              🎯 {session.user?.name || session.user?.email}님을 위한 맞춤 추천
+            </p>
+          ) : (
+            <p className="text-[#94A9C9] text-sm bg-[#12345D]/70 px-4 py-2 rounded-full inline-block">
+              📍 인기 여행지 추천 • 로그인하면 맞춤 추천을 받을 수 있어요
+            </p>
+          )}
+        </div>
+      )}
 
       {/* 추천 도시별 명소 섹션 (무한 스크롤) */}
       <main className="px-4 pb-24 space-y-12">
@@ -205,9 +224,8 @@ export default function Home() {
 
           <button
             onClick={() => {
-              // 임시로 로그인 상태를 확인 (실제 구현에서는 인증 상태를 확인)
-              const isLoggedIn = false // 여기서 실제 로그인 상태 확인
-              if (isLoggedIn) {
+              // 실제 로그인 상태 확인
+              if (session) {
                 router.push('/profile')
               } else {
                 router.push('/auth/login')

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
+import { signOut } from 'next-auth/react'
 
 interface TripCard {
   id: number
@@ -33,6 +34,10 @@ interface SavedItem {
 export default function ProfilePage() {
   const [activeTab, setActiveTab] = useState<'trips' | 'posts' | 'saved'>('trips')
   const router = useRouter()
+
+  const handleLogout = async () => {
+    await signOut({ callbackUrl: '/' })
+  }
 
   // 목업 데이터
   const trips: TripCard[] = [
@@ -261,11 +266,19 @@ export default function ProfilePage() {
           <span className="text-green-400 font-semibold">555</span>
         </div>
 
-        <Link href="/profile/edit">
-          <button className="w-64 bg-gray-200 text-gray-800 py-3 rounded-2xl font-medium hover:bg-gray-100 transition-colors">
-            Edit Profile
+        <div className="space-y-3">
+          <Link href="/profile/edit">
+            <button className="w-64 bg-gray-200 text-gray-800 py-3 rounded-2xl font-medium hover:bg-gray-100 transition-colors">
+              Edit Profile
+            </button>
+          </Link>
+          <button 
+            onClick={handleLogout}
+            className="w-64 bg-red-600 text-white py-3 rounded-2xl font-medium hover:bg-red-700 transition-colors"
+          >
+            로그아웃
           </button>
-        </Link>
+        </div>
       </div>
 
       {/* Tab Navigation */}

--- a/frontend/src/lib/dummyData.ts
+++ b/frontend/src/lib/dummyData.ts
@@ -17,13 +17,191 @@ export interface CitySection {
   recommendationScore: number // 추천 점수 (높을수록 상위 노출)
 }
 
-// 실제 백엔드 API에서 데이터 가져오기
-export const fetchRecommendedCities = async (
+// 토큰을 가져오는 함수 (Next-auth에서 사용)
+const getAuthToken = async (): Promise<string | null> => {
+  try {
+    if (typeof window === 'undefined') return null // SSR 체크
+    
+    // Next-auth 세션에서 토큰 가져오기
+    const { getSession } = await import('next-auth/react')
+    const session = await getSession()
+    
+    if (session && (session as any).backendToken) {
+      return (session as any).backendToken
+    }
+    
+    // fallback: localStorage에서 토큰을 가져오기
+    const token = localStorage.getItem('access_token')
+    return token
+  } catch (error) {
+    console.error('토큰 가져오기 오류:', error)
+    return null
+  }
+}
+
+// 실제 백엔드 추천 API에서 데이터 가져오기
+export const fetchRecommendations = async (
+  limit: number = 30  // 3개 섹션 × 10개 카드
+): Promise<{ data: any[], hasMore: boolean }> => {
+  try {
+    // 직접 localhost:8000으로 호출해보기 (개발환경)
+    const API_BASE_URL = 'http://localhost:8000'
+    
+    // 인증 토큰 가져오기
+    const token = await getAuthToken()
+    
+    // 헤더 설정
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'accept': 'application/json',
+    }
+    
+    // 토큰이 있으면 Authorization 헤더 추가
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`
+    }
+    
+    const url = `${API_BASE_URL}/api/v1/recommendations/mixed?limit=${limit}`
+    
+    const response = await fetch(url, {
+      method: 'GET',
+      headers
+    })
+    
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`HTTP error! status: ${response.status}, body: ${errorText}`)
+    }
+    
+    const recommendations = await response.json()
+    
+    // 디버깅: 백엔드에서 받은 데이터 확인 (제거)
+    // console.log('백엔드 추천 데이터 샘플:', recommendations.slice(0, 3))
+    
+    // 추천 데이터를 CitySection 형태로 변환
+    const transformedData = transformRecommendationsToSections(recommendations)
+    
+    return {
+      data: transformedData,
+      hasMore: false // 현재는 페이지네이션 없음
+    }
+  } catch (error) {
+    console.error('추천 API 호출 오류:', error)
+    // API 오류 시 fallback으로 기존 API 시도
+    return await fetchRecommendedCitiesFallback()
+  }
+}
+
+// 추천 데이터를 CitySection 형태로 변환하는 함수
+const transformRecommendationsToSections = (recommendations: any[]): CitySection[] => {
+  if (!recommendations || recommendations.length === 0) {
+    return []
+  }
+  
+  const MAX_SECTIONS = 3 // 최대 3개 섹션만 생성
+  const MIN_ITEMS_PER_SECTION = 5 // 섹션당 최소 5개 아이템
+  
+  // 지역별로 그룹핑
+  const regionGroups: { [key: string]: any[] } = {}
+  recommendations.forEach(place => {
+    const region = place.region || '기타'
+    if (!regionGroups[region]) {
+      regionGroups[region] = []
+    }
+    regionGroups[region].push(place)
+  })
+  
+  // 지역별 그룹을 섹션으로 변환
+  const sections: CitySection[] = []
+  const sortedRegions = Object.entries(regionGroups)
+    .sort(([,a], [,b]) => b.length - a.length) // 아이템 개수가 많은 지역 순으로 정렬
+  
+  for (const [region, places] of sortedRegions) {
+    if (sections.length >= MAX_SECTIONS) break
+    if (places.length < MIN_ITEMS_PER_SECTION) continue // 너무 적은 아이템은 제외
+    
+    // 최대 10개까지만 가져오기
+    const sectionPlaces = places.slice(0, 10)
+    
+    const attractions: Attraction[] = sectionPlaces.map(place => ({
+      id: place.place_id?.toString() || `${place.name}-${Math.random()}`,
+      name: place.name || '이름 없음',
+      description: place.description || '설명 없음',
+      imageUrl: '', // 이미지는 현재 없음
+      rating: 4.5, // 기본 평점
+      category: getCategoryFromTableName(place.table_name)
+    }))
+    
+    const firstPlace = sectionPlaces[0]
+    const sectionIndex = sections.length
+    
+    sections.push({
+      id: `section-${sectionIndex}`,
+      cityName: region,
+      description: firstPlace.recommendation_type === 'personalized' ? '맞춤 추천 여행지' : '인기 여행지',
+      region: region,
+      attractions,
+      recommendationScore: Math.round((firstPlace.similarity_score || 0.8) * 100)
+    })
+  }
+  
+  // 섹션이 부족한 경우 남은 장소들로 혼합 섹션 생성
+  if (sections.length < MAX_SECTIONS) {
+    const usedPlaces = new Set()
+    sections.forEach(section => {
+      section.attractions.forEach(attraction => {
+        usedPlaces.add(attraction.id)
+      })
+    })
+    
+    const remainingPlaces = recommendations.filter(place => 
+      !usedPlaces.has(place.place_id?.toString() || `${place.name}-${Math.random()}`)
+    )
+    
+    if (remainingPlaces.length > 0) {
+      const mixedPlaces = remainingPlaces.slice(0, 10)
+      const attractions: Attraction[] = mixedPlaces.map(place => ({
+        id: place.place_id?.toString() || `${place.name}-${Math.random()}`,
+        name: place.name || '이름 없음',
+        description: place.description || '설명 없음',
+        imageUrl: '', // 이미지는 현재 없음
+        rating: 4.5, // 기본 평점
+        category: getCategoryFromTableName(place.table_name)
+      }))
+      
+      sections.push({
+        id: `section-mixed`,
+        cityName: '추천 여행지',
+        description: '다양한 지역 추천',
+        region: '전국',
+        attractions,
+        recommendationScore: 80
+      })
+    }
+  }
+  
+  return sections
+}
+
+// 테이블명을 카테고리로 변환
+const getCategoryFromTableName = (tableName: string): 'accommodation' | 'humanities' | 'leisure_sport' | 'nature' | 'restaurants' | 'shopping' => {
+  const categoryMap: { [key: string]: 'accommodation' | 'humanities' | 'leisure_sport' | 'nature' | 'restaurants' | 'shopping' } = {
+    accommodation: 'accommodation',
+    humanities: 'humanities',
+    leisure_sports: 'leisure_sport',
+    nature: 'nature',
+    restaurants: 'restaurants',
+    shopping: 'shopping'
+  }
+  return categoryMap[tableName] || 'nature'
+}
+
+// 기존 API (fallback용)
+const fetchRecommendedCitiesFallback = async (
   page: number = 0,
   limit: number = 3
 ): Promise<{ data: CitySection[], hasMore: boolean }> => {
   try {
-    // 환경 변수에서 API URL을 가져오거나 기본값 사용
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
     const response = await fetch(`${API_BASE_URL}/api/v1/attractions/cities?page=${page}&limit=${limit}`)
     
@@ -38,8 +216,20 @@ export const fetchRecommendedCities = async (
       hasMore: result.hasMore
     }
   } catch (error) {
-    console.error('API 호출 오류:', error)
-    // API 오류 시 빈 데이터 반환
+    console.error('Fallback API 호출 오류:', error)
     return { data: [], hasMore: false }
+  }
+}
+
+// 기존 함수 유지 (하위 호환성) - page 매개변수를 무시하고 limit만 사용
+export const fetchRecommendedCities = async (page: number = 0, limit: number = 30) => {
+  try {
+    // page는 무시하고 limit만 사용 (새로운 추천 API는 페이지네이션을 지원하지 않음)
+    const result = await fetchRecommendations(limit)
+    return result
+  } catch (error) {
+    console.error('새로운 추천 API 실패:', error)
+    // 에러 발생시 fallback 호출
+    return await fetchRecommendedCitiesFallback(page, 3)
   }
 }


### PR DESCRIPTION
# Witple 프로젝트 변경 내역 보고서

본 보고서는 최근 **backend** 및 **frontend** 디렉토리의 주요 코드 변경 사항을 정리한 것입니다.  
변경 내용은 **추천 API 개선**, **인증/세션 처리 강화**, **프론트엔드 로그인/로그아웃 기능 반영**, **더미 데이터 제거 및 실제 DB 연동**에 초점이 맞춰져 있습니다.

---

## 1. Backend 변경 사항

### 1.1. `main.py`
- **CORS 허용 범위 확장**
  - 기존: `http://localhost:3000`
  - 추가: `http://localhost:3001` (Next.js 개발 서버 포트 대응)

---

### 1.2. `routers/recommendations.py`
- **추천 데이터 반환 방식 변경**
  - 로그인 사용자: 기존 로직 유지
  - 비로그인 사용자:  
    - 변경 전: 더미 데이터 반환  
    - 변경 후: `recommendation_engine.get_fallback_places(limit=limit)` 호출  
    - 실패 시: 최소 1개 실제 DB의 `restaurants` 데이터를 fallback으로 반환

---

### 1.3. `vectorization.py`
- **추천 엔진 벡터 처리 개선**
  - 장소 데이터 쿼리 변경:
    ```sql
    SELECT place_id, table_name, name, region, city, latitude, longitude, vector
    FROM place_features WHERE vector IS NOT NULL
    ORDER BY RANDOM() LIMIT 1000
    ```
  - **JSON 문자열 처리 추가**
    - DB에 `vector`가 문자열로 저장된 경우 → `json.loads` 후 numpy 배열 변환
  - **벡터 길이 검증**
    - 256차원만 허용
  - **사용자 벡터 생성**
    - BERT 결과를 `[:256]`으로 잘라 DB 벡터와 차원 일치 보장

---

## 2. Frontend 변경 사항

### 2.1. `src/app/api/auth/[...nextauth]/route.ts`
- **백엔드 API URL 로드 시 가독성 개선**
  - 환경 변수에서 `API_INTERNAL_URL` 또는 `NEXT_PUBLIC_API_URL` 우선 사용

---

### 2.2. `src/app/page.tsx`
- **세션 상태 연동**
  - `useSession()`을 활용하여 로그인 상태 확인
  - 초기 데이터 로드 시 `status !== 'loading'` 조건 추가
- **로그인 상태 표시**
  - 로그인: `"🎯 사용자 맞춤 추천"`
  - 비로그인: `"📍 인기 여행지 추천"`
- **프로필 접근 로직**
  - 변경 전: 하드코딩된 `isLoggedIn = false`
  - 변경 후: `if (session)` 조건으로 실제 로그인 여부 판별

---

### 2.3. `src/app/profile/page.tsx`
- **로그아웃 기능 추가**
  - `signOut({ callbackUrl: '/' })` 호출
  - 프로필 편집 버튼 하단에 로그아웃 버튼 배치

---

### 2.4. `src/lib/dummyData.ts`
- **추천 API 개선**
  - `fetchRecommendations(limit: number)` 함수 추가
  - `http://localhost:8000/api/v1/recommendations/mixed` 호출
  - `Authorization: Bearer <token>` 헤더 자동 포함
- **토큰 관리**
  - `next-auth` 세션에서 `backendToken` 조회
  - fallback: `localStorage`의 `access_token` 사용
- **추천 데이터 변환**
  - 지역(`region`)별로 그룹핑하여 최대 3개 `CitySection` 생성
  - 최소 5개 이상 장소가 있는 지역만 섹션화
  - 부족할 경우 혼합(`mixed`) 섹션 추가
- **하위 호환**
  - 기존 `fetchRecommendedCities(page, limit)`는 내부적으로 `fetchRecommendations` 호출
  - 실패 시 fallback API (`/api/v1/attractions/cities`) 사용

---

## 3. 주요 개선 효과
- **실제 DB 기반 추천**
  - 더 이상 더미 데이터가 아닌 실제 DB의 `place_features` 활용
  - 비로그인 사용자도 인기 여행지 추천 가능
- **세션 기반 맞춤 추천**
  - 로그인 시 사용자 맞춤 추천 표시
  - 비로그인 시 인기 여행지 추천 제공
- **데이터 일관성 보장**
  - BERT 벡터와 DB 벡터 차원 일치 (256차원)
  - JSON 문자열 형태의 벡터 처리 추가
- **사용자 경험 개선**
  - 로그인/로그아웃 기능 강화
  - 추천 섹션이 지역 단위로 묶여 가독성 향상

---

## 4. 차후 개선 방향
- **페이지네이션 지원**
  - 현재 추천 API는 무작위 1000개 샘플링 후 반환  
  - 향후 `offset/limit` 기반 페이지네이션 필요
- **이미지 필드 보강**
  - 추천 데이터에 실제 이미지 URL 추가 필요
- **추천 점수 시각화**
  - `similarity_score`를 UI에 반영해 개인화 추천 신뢰도 전달 가능

---

## 📌 결론
이번 변경으로 **Witple 서비스는 더미 데이터 기반에서 실제 DB 기반 추천 시스템으로 전환**되었으며,  
**로그인/비로그인 사용자별 맞춤 처리**가 가능해졌습니다.
