### PR TITLE
fix/일정 계획 카테고리 추천 알고리즘 적용 및 시간과 거리, 카테고리 숫자 지움

### DIFF
--- a/backend/routers/attractions.py
+++ b/backend/routers/attractions.py
@@ -7,8 +7,12 @@ from database import get_db
 from models import User
 from models_attractions import Nature, Restaurant, Shopping, Accommodation, Humanities, LeisureSports
 from schemas import UserResponse
+from routers.recommendations import get_current_user_optional, recommendation_engine, get_similarity_based_places
+import logging
 
 router = APIRouter(tags=["attractions"])
+
+logger = logging.getLogger(__name__)
 
 # 카테고리별 테이블 매핑
 CATEGORY_TABLES = {
@@ -89,6 +93,47 @@ def format_attraction_data(attraction, category: str, table_name: str = None):
         data["closedDays"] = getattr(attraction, 'closed_days', None)
     
     return data
+
+async def get_db_fallback_places(db: Session, region: str, category: str = None, limit: int = 20, exclude_ids: set = None):
+    """추천 엔진 실패시 DB에서 직접 가져오는 fallback"""
+    places = []
+    exclude_ids = exclude_ids or set()
+    
+    # 검색할 테이블들 결정
+    search_tables = {}
+    if category and category != 'all':
+        for table_name, table_model in CATEGORY_TABLES.items():
+            if get_category_from_table(table_name) == category:
+                search_tables[table_name] = table_model
+    else:
+        search_tables = CATEGORY_TABLES
+    
+    for table_name, table_model in search_tables.items():
+        if len(places) >= limit:
+            break
+            
+        # 지역으로 필터링
+        query = db.query(table_model).filter(
+            or_(
+                table_model.region.ilike(f"%{region}%"),
+                table_model.region == region,
+                table_model.city.ilike(f"%{region}%")
+            )
+        ).limit(limit - len(places))
+        
+        attractions = query.all()
+        table_category = get_category_from_table(table_name)
+        
+        for attraction in attractions:
+            place_id = f"{table_name}_{attraction.id}"
+            if place_id not in exclude_ids:
+                formatted_place = format_attraction_data(attraction, table_category, table_name)
+                places.append(formatted_place)
+                
+                if len(places) >= limit:
+                    break
+    
+    return places
 
 async def get_attractions_by_city(db: Session, city_name: str, limit: int = 8):
     """도시별 관광지 조회 - 각 카테고리에서 골고루 가져오기"""
@@ -319,6 +364,32 @@ def get_category_korean_name(category: str) -> str:
         "leisure_sports": "레저"
     }
     return category_map.get(category, category)
+
+
+def get_first_valid_image(image_urls):
+    """이미지 URL에서 첫 번째 유효한 이미지 반환"""
+    if not image_urls:
+        return None
+    
+    try:
+        if isinstance(image_urls, list) and len(image_urls) > 0:
+            for img_url in image_urls:
+                if img_url and img_url.strip() and img_url != "/images/default.jpg":
+                    return img_url
+        elif isinstance(image_urls, str):
+            if image_urls.startswith('[') and image_urls.endswith(']'):
+                import json
+                parsed_urls = json.loads(image_urls)
+                if isinstance(parsed_urls, list) and len(parsed_urls) > 0:
+                    for img_url in parsed_urls:
+                        if img_url and img_url.strip() and img_url != "/images/default.jpg":
+                            return img_url
+            elif image_urls.strip() and image_urls != "/images/default.jpg":
+                return image_urls
+    except Exception:
+        pass
+    
+    return None
 
 
 def sort_regions_by_priority(regions):
@@ -710,79 +781,152 @@ async def get_filtered_attractions(
     region: Optional[str] = Query(None, description="지역 필터"),
     category: Optional[str] = Query(None, description="카테고리 필터"),
     page: int = Query(0, ge=0, description="페이지 번호 (0부터 시작)"),
-    limit: int = Query(20, ge=1, le=100, description="페이지당 결과 수"),
+    limit: int = Query(50, ge=1, le=100, description="페이지당 결과 수"),
+    current_user = Depends(get_current_user_optional),
     db: Session = Depends(get_db)
 ):
-    """지역 및 카테고리별로 필터링된 관광지 목록을 가져옵니다."""
+    """일정 짜기 페이지용 추천 알고리즘 적용 관광지 목록"""
     try:
+        logger.info(f"Filtered attractions request: region={region}, category={category}, limit={limit}")
+        
+        # 지역이 필수로 필요함 (일정 짜기 페이지는 특정 지역 기반)
+        if not region:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="지역을 선택해주세요."
+            )
+        
         results = []
         
-        # 카테고리 필터에 따른 테이블 선택
-        search_tables = {}
-        if category:
-            # 카테고리에 맞는 테이블만 검색
-            for table_name, table_model in CATEGORY_TABLES.items():
-                table_category = get_category_from_table(table_name)
-                if table_category == category:
-                    search_tables[table_name] = table_model
-        else:
-            # 모든 테이블 검색
-            search_tables = CATEGORY_TABLES
-        
-        # 각 테이블에서 필터링된 결과 조회
-        for table_name, table_model in search_tables.items():
-            query = db.query(table_model)
+        # 로그인 상태에 따른 추천 알고리즘 적용
+        if current_user and hasattr(current_user, 'user_id'):
+            # 로그인 시: 개인화 추천 + 코사인 유사도 혼합
+            user_id = str(current_user.user_id)
+            logger.info(f"Personalized recommendations for user: {user_id}")
             
-            # 지역 필터
-            if region:
-                query = query.filter(
-                    or_(
-                        table_model.region.ilike(f"%{region}%"),
-                        table_model.region == region
-                    )
+            try:
+                # 개인화 추천 (상단 절반)
+                personalized_limit = min(25, limit // 2)
+                personalized_places = await recommendation_engine.get_personalized_recommendations(
+                    user_id=user_id,
+                    region=region,
+                    category=category,
+                    limit=personalized_limit
                 )
+                
+                # 코사인 유사도 기반 (하단 절반) - 중복 제거
+                used_place_ids = {f"{p['table_name']}_{p['place_id']}" for p in personalized_places}
+                similarity_limit = limit - len(personalized_places)
+                similarity_places = await get_similarity_based_places(
+                    region=region,
+                    category=category,
+                    limit=similarity_limit,
+                    exclude_ids=used_place_ids
+                )
+                
+                # 결과 결합 및 포맷팅
+                all_recommendations = personalized_places + similarity_places
+                
+                for i, place in enumerate(all_recommendations):
+                    # recommendations 형태를 attractions 형태로 변환
+                    formatted_attraction = {
+                        "id": f"{place['table_name']}_{place['place_id']}",
+                        "name": place.get('name', '이름 없음'),
+                        "description": place.get('description', '설명 없음'),
+                        "imageUrl": get_first_valid_image(place.get('image_urls')),
+                        "rating": round((place.get('similarity_score', 0.7) + 0.3) * 5, 1),
+                        "category": get_category_from_table(place['table_name']),
+                        "region": place.get('region', region),
+                        "city": {
+                            "name": place.get('city', '알 수 없음'),
+                            "region": place.get('region', region)
+                        },
+                        "latitude": place.get('latitude'),
+                        "longitude": place.get('longitude'),
+                        "sourceTable": place['table_name'],
+                        "recommendationType": "personalized" if i < len(personalized_places) else "similarity"
+                    }
+                    results.append(formatted_attraction)
+                
+                logger.info(f"Retrieved {len(results)} personalized attractions")
+                
+            except Exception as e:
+                logger.error(f"Personalized recommendations failed: {str(e)}")
+                # 개인화 실패시 유사도 기반으로 fallback
+                similarity_places = await get_similarity_based_places(
+                    region=region,
+                    category=category,
+                    limit=limit,
+                    exclude_ids=set()
+                )
+                
+                for place in similarity_places:
+                    formatted_attraction = {
+                        "id": f"{place['table_name']}_{place['place_id']}",
+                        "name": place.get('name', '이름 없음'),
+                        "description": place.get('description', '설명 없음'),
+                        "imageUrl": get_first_valid_image(place.get('image_urls')),
+                        "rating": round((place.get('similarity_score', 0.7) + 0.3) * 5, 1),
+                        "category": get_category_from_table(place['table_name']),
+                        "region": place.get('region', region),
+                        "city": {
+                            "name": place.get('city', '알 수 없음'),
+                            "region": place.get('region', region)
+                        },
+                        "latitude": place.get('latitude'),
+                        "longitude": place.get('longitude'),
+                        "sourceTable": place['table_name'],
+                        "recommendationType": "similarity"
+                    }
+                    results.append(formatted_attraction)
+        
+        else:
+            # 비로그인 시: 코사인 유사도만
+            logger.info("Guest user - similarity based recommendations")
+            similarity_places = await get_similarity_based_places(
+                region=region,
+                category=category,
+                limit=limit,
+                exclude_ids=set()
+            )
             
-            # 페이지네이션 적용하여 검색 결과 조회
-            offset = page * limit
-            attractions = query.offset(offset).limit(limit).all()
-            
-            # 결과 포맷팅
-            table_category = get_category_from_table(table_name)
-            for attraction in attractions:
-                formatted_attraction = format_attraction_data(attraction, table_category, table_name)
-                formatted_attraction["city"] = {
-                    "id": attraction.city.lower().replace(" ", "-") if attraction.city else "unknown",
-                    "name": attraction.city or "알 수 없음",
-                    "region": attraction.region or "알 수 없음"
+            for place in similarity_places:
+                formatted_attraction = {
+                    "id": f"{place['table_name']}_{place['place_id']}",
+                    "name": place.get('name', '이름 없음'),
+                    "description": place.get('description', '설명 없음'),
+                    "imageUrl": get_first_valid_image(place.get('image_urls')),
+                    "rating": round((place.get('similarity_score', 0.7) + 0.3) * 5, 1),
+                    "category": get_category_from_table(place['table_name']),
+                    "region": place.get('region', region),
+                    "city": {
+                        "name": place.get('city', '알 수 없음'),
+                        "region": place.get('region', region)
+                    },
+                    "latitude": place.get('latitude'),
+                    "longitude": place.get('longitude'),
+                    "sourceTable": place['table_name'],
+                    "recommendationType": "similarity"
                 }
                 results.append(formatted_attraction)
-        
-        # 전체 결과 개수 계산
-        total_results = 0
-        for table_name, table_model in search_tables.items():
-            query = db.query(table_model)
-            if region:
-                query = query.filter(
-                    or_(
-                        table_model.region.ilike(f"%{region}%"),
-                        table_model.region == region
-                    )
-                )
-            total_results += query.count()
         
         return {
             "attractions": results,
             "total": len(results),
-            "totalAvailable": total_results,
+            "totalAvailable": len(results),
             "page": page,
             "limit": limit,
-            "hasMore": (page + 1) * limit < total_results,
+            "hasMore": False,  # 일정 짜기에서는 페이지네이션 없이 한 번에 모든 결과 반환
             "filters": {
                 "region": region,
                 "category": category
             }
         }
+        
+    except HTTPException:
+        raise
     except Exception as e:
+        logger.error(f"Error in filtered attractions: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"필터링된 관광지 조회 중 오류 발생: {str(e)}"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -423,7 +423,14 @@ export default function Home() {
         {/* 데이터가 없을 때 */}
         {!loading && citySections.length === 0 && (
           <div className="text-center py-16">
-            <p className="text-[#94A9C9] text-lg">추천할 여행지를 준비 중입니다...</p>
+            {session ? (
+              <>
+                <p className="text-[#94A9C9] text-lg mb-4">맞춤 추천을 준비하고 있어요!</p>
+                <p className="text-[#6FA0E6] text-sm">선호도 설정이나 여행지 탐색 후 다시 확인해보세요 ✨</p>
+              </>
+            ) : (
+              <p className="text-[#94A9C9] text-lg">추천할 여행지를 준비 중입니다...</p>
+            )}
           </div>
         )}
       </main>


### PR DESCRIPTION


## 1. 🧑‍💻 백엔드 (Backend) 변경 사항

### ✨ 신규 기능 및 핵심 로직 변경

1.  **`attractions.py`: 관광지 필터링 로직 전면 개편 (`GET /filtered`)**
    * 기존의 DB 페이지네이션 기반 `get_filtered_attractions` 엔드포인트 로직을 **추천 엔진 기반**으로 완전히 대체했습니다.
    * 이제 이 엔드포인트는 **일정 짜기 페이지 전용** 데이터 소스로 작동하며, 페이지네이션 대신 **단일 추천 목록**을 반환합니다 (`hasMore: False` 고정).
    * **로그인 사용자:** 상위 50%는 **개인화 추천** (`get_personalized_recommendations`), 하위 50%는 **유사도 기반 추천** (`get_similarity_based_places`) 결과를 조합하여 반환합니다. (중복 제거 포함)
    * **비로그인 사용자 (게스트):** **유사도 기반 추천** (`get_similarity_based_places`) 결과만 반환합니다.
    * 개인화 추천 로직 실패 시, 유사도 기반 추천으로 자동 Fallback됩니다.

2.  **`recommendations.py`: 신규 추천 엔드포인트 및 헬퍼 추가**
    * **`GET /itinerary/{place_id}` (신규 엔드포인트):**
        * 일정 짜기 페이지의 시작점이 되는 **신규 API**입니다.
        * `place_id` (예: `nature_123`)를 받아 해당 장소의 **지역(region)을 DB에서 조회**한 후, 해당 지역을 기준으로 `/filtered` 엔드포인트와 동일한 추천 로직(개인화+유사도)을 수행합니다.
    * **`get_similarity_based_places` (신규 헬퍼):**
        * Raw SQL(`asyncpg`)을 사용하여 특정 지역(`region`) 및 카테고리를 기준으로 장소를 추천하는 함수입니다. (현재 `similarity_score`는 `random()`으로 시뮬레이션되어 있습니다.)
        * `exclude_ids`를 받아 이미 추천된 장소를 제외하는 기능이 포함되어 있습니다.
    * **`get_place_region` (신규 헬퍼):**
        * 테이블명과 ID를 받아 해당 장소의 지역 정보를 반환합니다.

3.  **`recommendations.py`: 기존 추천 로직 강화**
    * `get_personalized_region_categories` (홈 화면 추천) 로직이 개선되었습니다.
    * 개인화 추천 데이터풀을 100개에서 **500개로 확대**하여 지역/카테고리 분석 정확도를 높였습니다.
    * 사용자 선호 태그(예: '맛집', '바다')를 분석하여, **선호 카테고리는 최대 15개**, 비선호 카테고리는 최대 10개를 반환하도록 차등 분배 로직을 적용했습니다. (기존: 일괄 8개)
    * 최소 3개 이상의 장소가 확보된 카테고리만 노출하도록 하여 품질을 보장합니다.

4.  **`vectorization.py`: 추천 엔진 안정성 및 성능 개선**
    * **`get_fallback_places` (Fallback 로직 개선):**
        * 기존: `ORDER BY RANDOM()`.
        * **변경:** `user_action_logs`를 분석하여 **인기도(popularity)와 최신성(freshness)**을 기반으로 가중치를 부여하는 복잡한 Fallback 로직으로 변경되었습니다. (단순 랜덤 -> 인기순)
    * **`get_personalized_recommendations` (안정성 강화):**
        * 추천 로직 전체를 거대한 `try...except` 블록으로 감쌌습니다. 추천 생성 중 어떤 단계에서든 오류 발생 시, 즉시 위에서 개선된 `get_fallback_places`를 호출하도록 하여 **엔진 다운을 방지**합니다.
    * **`_get_user_profile_vector` (프로필 생성 튜닝):**
        * 사용자 선호 태그의 가중치를 2배로 증폭(`calculated_weight * 2`)시켜 사용자 취향을 더 강력하게 반영합니다.

---

## 2. 🎨 프론트엔드 (Frontend) 변경 사항

### ✨ 핵심 기능 변경 (일정 짜기 페이지)

1.  **`itinerary/[attractionId]/page.tsx`: 데이터 로딩 로직 전면 개편**
    * 페이지의 기본 데이터 소스를 기존 `/search` API에서 새로운 **`/attractions/filtered` (추천 API)로 변경**했습니다.
    * **강력한 다단계 Fallback 로직 구현:**
        1.  **(1순위)** 신규 `/filtered` 추천 API를 호출합니다.
        2.  **(2순위)** 1번이 실패하거나 결과가 10개 미만일 경우, 기존 `/search` API(지역 기반)로 자동 Fallback합니다.
        3.  **(3순위)** 2번 결과도 부족할 경우, 전국 단위 검색으로 추가 Fallback을 시도하여 **어떤 상황에서도 콘텐츠가 표시되도록 보장**합니다.
    * 카테고리 변경 시(예: '전체' -> '맛집')에도 추천 API (`loadFilteredAttractions`)를 다시 호출하도록 `useEffect`를 추가했습니다.
    * 페이지네이션 및 '더 보기' 로직을 제거하고, 추천 API가 반환하는 **단일 목록 전체를 렌더링**하도록 변경했습니다.
