### PR TITLE
Feat/save plan reopen

### DIFF
--- a/backend/routers/trips.py
+++ b/backend/routers/trips.py
@@ -169,7 +169,8 @@ async def create_trip(
                     "table_name": table_name,
                     "id": actual_id,
                     "dayNumber": day_number,
-                    "order": day_counters[day_number]  # 일차별로 1부터 시작
+                    "order": day_counters[day_number],  # 일차별로 1부터 시작
+                    "isLocked": place.get("isLocked", False)  # 잠금 상태 추가
                 }
                 simplified_places.append(simplified_place)
         
@@ -271,7 +272,8 @@ async def update_trip(
                     "table_name": table_name,
                     "id": actual_id,
                     "dayNumber": day_number,
-                    "order": day_counters[day_number]  # 일차별로 1부터 시작
+                    "order": day_counters[day_number],  # 일차별로 1부터 시작
+                    "isLocked": place.get("isLocked", False)  # 잠금 상태 추가
                 }
                 simplified_places.append(simplified_place)
         

--- a/backend/routers/trips.py
+++ b/backend/routers/trips.py
@@ -142,7 +142,6 @@ async def create_trip(
             day_counters = {}  # 각 일차별 카운터
             
             for place in places:
-                place_id = place.get("id", "")
                 day_number = place.get("dayNumber", 1)
                 
                 # 일차별 카운터 관리
@@ -151,14 +150,20 @@ async def create_trip(
                 else:
                     day_counters[day_number] += 1
                 
-                # id에서 테이블명과 실제 ID 분리 (예: leisure_sports_950 -> leisure_sports, 950)
-                table_name = ""
-                actual_id = ""
-                if "_" in place_id:
-                    parts = place_id.rsplit("_", 1)  # 마지막 언더스코어로 분리
-                    if len(parts) == 2:
-                        table_name = parts[0]
-                        actual_id = parts[1]
+                # 프론트엔드에서 이미 분리된 데이터를 보낸 경우
+                if place.get("table_name") and place.get("id"):
+                    table_name = place.get("table_name", "")
+                    actual_id = place.get("id", "")
+                else:
+                    # 아직 분리되지 않은 데이터를 보낸 경우 (레거시 호환성)
+                    place_id = place.get("id", "")
+                    table_name = ""
+                    actual_id = ""
+                    if "_" in place_id:
+                        parts = place_id.rsplit("_", 1)  # 마지막 언더스코어로 분리
+                        if len(parts) == 2:
+                            table_name = parts[0]
+                            actual_id = parts[1]
                 
                 simplified_place = {
                     "table_name": table_name,
@@ -211,10 +216,10 @@ async def create_trip(
         )
 
 
-@router.put("/{trip_id}", response_model=TripResponse)
+@router.put("/{trip_id}")
 async def update_trip(
     trip_id: int,
-    trip_data: TripCreate,
+    trip_data: dict,  # 프론트엔드 데이터를 직접 받음
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user)
 ):
@@ -231,60 +236,74 @@ async def update_trip(
         )
     
     try:
-        # feat 브랜치의 최적화된 places 저장 방식 적용
+        # feat 브랜치의 최적화된 places 저장 방식 적용 (POST와 동일한 로직)
         simplified_places = []
-        if trip_data.places:
-            day_counters = {}
+        places = trip_data.get("places", [])
+        if places:
+            # 일차별로 그룹핑하여 각 일차마다 order를 1부터 시작
+            day_counters = {}  # 각 일차별 카운터
             
-            for place in trip_data.places:
-                place_dict = place.dict() if hasattr(place, 'dict') else place
+            for place in places:
+                day_number = place.get("dayNumber", 1)
                 
-                place_id = place_dict.get("id", "")
-                day_number = place_dict.get("dayNumber", 1)
-                
+                # 일차별 카운터 관리
                 if day_number not in day_counters:
                     day_counters[day_number] = 1
                 else:
                     day_counters[day_number] += 1
                 
-                table_name = ""
-                actual_id = ""
-                if "_" in place_id:
-                    parts = place_id.rsplit("_", 1)
-                    if len(parts) == 2:
-                        table_name = parts[0]
-                        actual_id = parts[1]
+                # 프론트엔드에서 이미 분리된 데이터를 보낸 경우
+                if place.get("table_name") and place.get("id"):
+                    table_name = place.get("table_name", "")
+                    actual_id = place.get("id", "")
+                else:
+                    # 아직 분리되지 않은 데이터를 보낸 경우 (레거시 호환성)
+                    place_id = place.get("id", "")
+                    table_name = ""
+                    actual_id = ""
+                    if "_" in place_id:
+                        parts = place_id.rsplit("_", 1)  # 마지막 언더스코어로 분리
+                        if len(parts) == 2:
+                            table_name = parts[0]
+                            actual_id = parts[1]
                 
                 simplified_place = {
                     "table_name": table_name,
                     "id": actual_id,
                     "dayNumber": day_number,
-                    "order": day_counters[day_number]
+                    "order": day_counters[day_number]  # 일차별로 1부터 시작
                 }
                 simplified_places.append(simplified_place)
         
         places_json = json.dumps(simplified_places) if simplified_places else None
         
+        # 날짜 문자열을 datetime으로 변환 (프론트엔드에서 camelCase로 보냄)
+        start_date = None
+        end_date = None
+        
+        if trip_data.get("start_date"):
+            start_date = datetime.fromisoformat(trip_data["start_date"])
+        if trip_data.get("end_date"):
+            end_date = datetime.fromisoformat(trip_data["end_date"])
+        
         # Trip 정보 업데이트
-        trip.title = trip_data.title
+        trip.title = trip_data.get("title", trip.title)
         trip.places = places_json
-        trip.start_date = trip_data.start_date
-        trip.end_date = trip_data.end_date
-        trip.status = trip_data.status.value if hasattr(trip_data, 'status') and trip_data.status else trip.status
-        trip.total_budget = trip_data.total_budget if hasattr(trip_data, 'total_budget') else trip.total_budget
-        trip.cover_image = trip_data.cover_image if hasattr(trip_data, 'cover_image') else trip.cover_image
-        trip.description = trip_data.description
+        trip.start_date = start_date if start_date else trip.start_date
+        trip.end_date = end_date if end_date else trip.end_date
+        trip.total_budget = trip_data.get("total_budget", trip.total_budget)
+        trip.cover_image = trip_data.get("cover_image", trip.cover_image)
+        trip.description = trip_data.get("description", trip.description)
         
         db.commit()
         db.refresh(trip)
         
-        # places를 파싱하여 반환
-        if trip.places:
-            trip.places = json.loads(trip.places)
-        else:
-            trip.places = []
-        
-        return trip
+        # 성공 응답 반환 (POST와 유사한 형식)
+        return {
+            "message": "여행이 성공적으로 수정되었습니다.",
+            "trip_id": trip.id,
+            "title": trip.title
+        }
         
     except Exception as e:
         db.rollback()

--- a/frontend/src/app/api.ts
+++ b/frontend/src/app/api.ts
@@ -94,4 +94,16 @@ export const saveTrip = async (tripData: {
   return response.data
 }
 
+export const updateTrip = async (tripId: number, tripData: {
+  title: string
+  description?: string | null
+  places: any[]
+  start_date?: string
+  end_date?: string
+  days?: number
+}) => {
+  const response = await apiClient.put(`/api/v1/trips/${tripId}`, tripData)
+  return response.data
+}
+
 export default apiClient

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -83,12 +83,19 @@ export default function MapPage() {
   const tripTitleParam = searchParams.get('tripTitle')
   const tripDescriptionParam = searchParams.get('tripDescription')
   const tripIdParam = searchParams.get('tripId')
+  const editModeParam = searchParams.get('editMode')
   
   // profile에서 온 경우 판단
   const isFromProfile = sourceParam === 'profile'
   
-  // 편집 모드 상태 (profile에서 온 경우에만 사용)
-  const [isEditMode, setIsEditMode] = useState(false)
+  // 편집 모드 상태 (profile에서 온 경우에만 사용, editMode 파라미터가 있으면 자동 활성화)
+  const [isEditMode, setIsEditMode] = useState(editModeParam === 'true')
+  
+  // long press 활성화 조건 계산 (동적으로 변경되도록)
+  // 1. profile이 아닌 곳에서 온 경우: 항상 가능
+  // 2. profile에서 왔지만 편집 모드가 활성화된 경우: 가능
+  // 3. profile에서 왔고 편집 모드가 비활성화된 경우: 불가능
+  const isLongPressEnabled = !isFromProfile || isEditMode
   const [editTitle, setEditTitle] = useState(tripTitleParam ? decodeURIComponent(tripTitleParam) : '')
   const [editDescription, setEditDescription] = useState(tripDescriptionParam && tripDescriptionParam.trim() 
     ? decodeURIComponent(tripDescriptionParam) 
@@ -1965,16 +1972,24 @@ export default function MapPage() {
                             data-place-card="true"
                             className="bg-[#1F3C7A]/20 border border-[#1F3C7A]/40 rounded-xl p-4 hover:bg-[#1F3C7A]/30 transition-colors relative cursor-pointer select-none group"
                             onTouchStart={(e) => {
-                              handleLongPressStart(e, place, day, index);
+                              if (isLongPressEnabled) {
+                                handleLongPressStart(e, place, day, index);
+                              }
                             }}
                             onTouchMove={(e) => {
-                              handleLongPressMove(e);
+                              if (isLongPressEnabled) {
+                                handleLongPressMove(e);
+                              }
                             }}
                             onTouchEnd={(e) => {
-                              handleLongPressEnd(e);
+                              if (isLongPressEnabled) {
+                                handleLongPressEnd(e);
+                              }
                             }}
                             onTouchCancel={(e) => {
-                              handleLongPressEnd(e);
+                              if (isLongPressEnabled) {
+                                handleLongPressEnd(e);
+                              }
                             }}
                             style={{ 
                               touchAction: 'none',
@@ -1983,12 +1998,14 @@ export default function MapPage() {
                               WebkitTouchCallout: 'none'
                             } as React.CSSProperties}
                           >
-                            {/* Long press 말풍선 힌트 */}
-                            <div className="absolute -top-3 -left-3 opacity-0 group-hover:opacity-100 transition-all duration-300 pointer-events-none z-20">
-                              <div className="relative bg-[#0B1220] text-white text-xs px-3 py-2 rounded-xl shadow-xl whitespace-nowrap border border-gray-300/60">
-                                꾹 눌러 이동
+                            {/* Long press 말풍선 힌트 (long press가 활성화된 경우에만 표시) */}
+                            {isLongPressEnabled && (
+                              <div className="absolute -top-3 -left-3 opacity-0 group-hover:opacity-100 transition-all duration-300 pointer-events-none z-20">
+                                <div className="relative bg-[#0B1220] text-white text-xs px-3 py-2 rounded-xl shadow-xl whitespace-nowrap border border-gray-300/60">
+                                  꾹 눌러 이동
+                                </div>
                               </div>
-                            </div>
+                            )}
                             
                             {/* 잠금 버튼 - 휴지통 왼쪽 */}
                             {(!isFromProfile || isEditMode) && (

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -320,14 +320,11 @@ export default function MapPage() {
         
         // 잠금 상태 복원
         if (lockedPlacesParam) {
-          console.log('lockedPlacesParam:', lockedPlacesParam)
           const lockedKeys = lockedPlacesParam.split(',')
-          console.log('lockedKeys:', lockedKeys)
           const restoredLockedPlaces: {[key: string]: boolean} = {}
           lockedKeys.forEach(key => {
             restoredLockedPlaces[key] = true
           })
-          console.log('restoredLockedPlaces:', restoredLockedPlaces)
           setLockedPlaces(restoredLockedPlaces)
         }
       } catch (error) {
@@ -2036,12 +2033,7 @@ export default function MapPage() {
                                 }`}
                                 title={lockedPlaces[`${place.id}_${day}`] ? "순서 고정 해제" : "순서 고정"}
                               >
-                              {(() => {
-                                const lockKey = `${place.id}_${day}`;
-                                const isLocked = lockedPlaces[lockKey];
-                                console.log(`장소 ${place.name} (${place.id}) - 키: ${lockKey}, 잠금상태: ${isLocked}`);
-                                return isLocked;
-                              })() ? (
+                              {lockedPlaces[`${place.id}_${day}`] ? (
                                 <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
                                 </svg>

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -86,6 +86,9 @@ export default function MapPage() {
   // profile에서 온 경우 판단
   const isFromProfile = sourceParam === 'profile'
   
+  // 편집 모드 상태 (profile에서 온 경우에만 사용)
+  const [isEditMode, setIsEditMode] = useState(false)
+  
   const [selectedItineraryPlaces, setSelectedItineraryPlaces] = useState<SelectedPlace[]>([])
   const [categoryPlaces, setCategoryPlaces] = useState<AttractionData[]>([])
   const [categoryLoading, setCategoryLoading] = useState(false)
@@ -1519,8 +1522,8 @@ export default function MapPage() {
         </button>
       </div>
 
-      {/* Search Bar - profile에서 온 경우 숨기기 */}
-      {!isFromProfile && (
+      {/* Search Bar - profile에서 온 경우 편집 모드에서만 표시 */}
+      {(!isFromProfile || isEditMode) && (
         <div className="absolute top-4 left-16 right-4 z-40">
         <form onSubmit={handleSearch} className="relative">
           <div className="relative">
@@ -1544,8 +1547,8 @@ export default function MapPage() {
         </div>
       )}
 
-      {/* Category Filter - profile에서 온 경우 숨기기 */}
-      {!isFromProfile && (
+      {/* Category Filter - profile에서 온 경우 편집 모드에서만 표시 */}
+      {(!isFromProfile || isEditMode) && (
       <div className="absolute top-20 left-4 right-4 z-40">
         <div className="flex space-x-2 overflow-x-auto no-scrollbar">
           {categories.map(category => (
@@ -1675,6 +1678,17 @@ export default function MapPage() {
                   <h2 className="text-xl font-bold text-[#3E68FF]">내 일정</h2>
                 )}
                 <div className="flex items-center space-x-2">
+                  {isFromProfile && (
+                    <button
+                      onClick={() => setIsEditMode(!isEditMode)}
+                      className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors flex items-center space-x-1"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
+                      <span>{isEditMode ? '편집 완료' : '편집'}</span>
+                    </button>
+                  )}
                   {(directionsRenderers.length > 0 || sequenceMarkers.length > 0) && (
                     <button
                       onClick={clearRoute}
@@ -1687,7 +1701,7 @@ export default function MapPage() {
                       <span>경로 지우기</span>
                     </button>
                   )}
-                  {!isFromProfile && (
+                  {(!isFromProfile || isEditMode) && (
                     <button
                       onClick={() => setShowItinerary(false)}
                       className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors"
@@ -1849,18 +1863,19 @@ export default function MapPage() {
                             </div>
                             
                             {/* 잠금 버튼 - 휴지통 왼쪽 */}
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                toggleLockPlace(place.id, day);
-                              }}
-                              className={`absolute -top-2 right-8 w-8 h-8 border rounded-full flex items-center justify-center shadow-lg transition-all duration-200 group hover:scale-110 z-10 ${
-                                lockedPlaces[`${place.id}_${day}`] 
-                                  ? 'bg-[#FF9800]/80 hover:bg-[#FF9800] border-[#FF9800]/30 hover:border-[#FF9800]/50' 
-                                  : 'bg-[#1F3C7A]/80 hover:bg-[#1F3C7A] border-[#3E68FF]/30 hover:border-[#3E68FF]/50'
-                              }`}
-                              title={lockedPlaces[`${place.id}_${day}`] ? "순서 고정 해제" : "순서 고정"}
-                            >
+                            {(!isFromProfile || isEditMode) && (
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleLockPlace(place.id, day);
+                                }}
+                                className={`absolute -top-2 right-8 w-8 h-8 border rounded-full flex items-center justify-center shadow-lg transition-all duration-200 group hover:scale-110 z-10 ${
+                                  lockedPlaces[`${place.id}_${day}`] 
+                                    ? 'bg-[#FF9800]/80 hover:bg-[#FF9800] border-[#FF9800]/30 hover:border-[#FF9800]/50' 
+                                    : 'bg-[#1F3C7A]/80 hover:bg-[#1F3C7A] border-[#3E68FF]/30 hover:border-[#3E68FF]/50'
+                                }`}
+                                title={lockedPlaces[`${place.id}_${day}`] ? "순서 고정 해제" : "순서 고정"}
+                              >
                               {lockedPlaces[`${place.id}_${day}`] ? (
                                 <svg className="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
@@ -1870,10 +1885,12 @@ export default function MapPage() {
                                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z" />
                                 </svg>
                               )}
-                            </button>
+                              </button>
+                            )}
 
                             {/* 휴지통 버튼 - 오른쪽 상단 모서리 */}
-                            <button
+                            {(!isFromProfile || isEditMode) && (
+                              <button
                               onClick={(e) => {
                                 e.stopPropagation();
                                 openDeleteConfirm(place, day);
@@ -1881,10 +1898,11 @@ export default function MapPage() {
                               className="absolute -top-2 -right-2 w-8 h-8 bg-[#1F3C7A]/80 hover:bg-[#1F3C7A] border border-[#3E68FF]/30 hover:border-[#3E68FF]/50 rounded-full flex items-center justify-center shadow-lg transition-all duration-200 group hover:scale-110 z-10"
                               title="일정에서 제거"
                             >
-                              <svg className="w-4 h-4 text-[#94A9C9] group-hover:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-              </svg>
-                            </button>
+                                <svg className="w-4 h-4 text-[#94A9C9] group-hover:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                </svg>
+                              </button>
+                            )}
 
                             <div className="flex items-start justify-between">
                               <div 
@@ -2141,7 +2159,7 @@ export default function MapPage() {
             </div>
           )}
           
-          {/* 일정 저장하기 버튼 - profile에서 온 경우 숨기기 */}
+          {/* 일정 저장/수정하기 버튼 - 편집 모드에서는 숨기기 */}
           {showItinerary && selectedItineraryPlaces.length > 0 && !isFromProfile && (
             <div className="px-4 pb-8 pt-4">
               <button

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -2514,7 +2514,7 @@ export default function MapPage() {
                       setTimeout(() => {
                         setSaveToast({ show: false, message: '', type: 'success' });
                         router.push('/profile');
-                      }, 1500);
+                      }, 1000);
                       
                       closeSaveItinerary();
                     } catch (error) {

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -79,6 +79,12 @@ export default function MapPage() {
   const startDateParam = searchParams.get('startDate')
   const endDateParam = searchParams.get('endDate')
   const daysParam = searchParams.get('days')
+  const sourceParam = searchParams.get('source')
+  const tripTitleParam = searchParams.get('tripTitle')
+  const tripDescriptionParam = searchParams.get('tripDescription')
+  
+  // profile에서 온 경우 판단
+  const isFromProfile = sourceParam === 'profile'
   
   const [selectedItineraryPlaces, setSelectedItineraryPlaces] = useState<SelectedPlace[]>([])
   const [categoryPlaces, setCategoryPlaces] = useState<AttractionData[]>([])
@@ -1513,8 +1519,9 @@ export default function MapPage() {
         </button>
       </div>
 
-      {/* Search Bar */}
-      <div className="absolute top-4 left-16 right-4 z-40">
+      {/* Search Bar - profile에서 온 경우 숨기기 */}
+      {!isFromProfile && (
+        <div className="absolute top-4 left-16 right-4 z-40">
         <form onSubmit={handleSearch} className="relative">
           <div className="relative">
             <input
@@ -1534,9 +1541,11 @@ export default function MapPage() {
             </button>
           </div>
         </form>
-      </div>
+        </div>
+      )}
 
-      {/* Category Filter */}
+      {/* Category Filter - profile에서 온 경우 숨기기 */}
+      {!isFromProfile && (
       <div className="absolute top-20 left-4 right-4 z-40">
         <div className="flex space-x-2 overflow-x-auto no-scrollbar">
           {categories.map(category => (
@@ -1558,6 +1567,7 @@ export default function MapPage() {
           ))}
         </div>
       </div>
+      )}
 
       {/* Route Status Toast */}
       {routeStatus && (
@@ -1651,7 +1661,19 @@ export default function MapPage() {
             /* 일정 보기 모드 */
             <div className="px-4 py-4">
               <div className="flex items-center justify-between mb-6">
-                <h2 className="text-xl font-bold text-[#3E68FF]">내 일정</h2>
+                {isFromProfile && tripTitleParam ? (
+                  <div>
+                    <h2 className="text-xl font-bold text-[#3E68FF]">{decodeURIComponent(tripTitleParam)}</h2>
+                    <p className="text-sm text-[#94A9C9]">
+                      {tripDescriptionParam && tripDescriptionParam.trim() 
+                        ? decodeURIComponent(tripDescriptionParam)
+                        : '저장된 여행 일정'
+                      }
+                    </p>
+                  </div>
+                ) : (
+                  <h2 className="text-xl font-bold text-[#3E68FF]">내 일정</h2>
+                )}
                 <div className="flex items-center space-x-2">
                   {(directionsRenderers.length > 0 || sequenceMarkers.length > 0) && (
                     <button
@@ -1665,12 +1687,14 @@ export default function MapPage() {
                       <span>경로 지우기</span>
                     </button>
                   )}
-                  <button
-                    onClick={() => setShowItinerary(false)}
-                    className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors"
-                  >
-                    장소 찾기
-                  </button>
+                  {!isFromProfile && (
+                    <button
+                      onClick={() => setShowItinerary(false)}
+                      className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors"
+                    >
+                      장소 찾기
+                    </button>
+                  )}
                 </div>
               </div>
               
@@ -2117,8 +2141,8 @@ export default function MapPage() {
             </div>
           )}
           
-          {/* 일정 저장하기 버튼 */}
-          {showItinerary && selectedItineraryPlaces.length > 0 && (
+          {/* 일정 저장하기 버튼 - profile에서 온 경우 숨기기 */}
+          {showItinerary && selectedItineraryPlaces.length > 0 && !isFromProfile && (
             <div className="px-4 pb-8 pt-4">
               <button
                 onClick={openSaveItinerary}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -119,8 +119,43 @@ export default function ProfilePage() {
   const [isUpdatingPost, setIsUpdatingPost] = useState(false)
   const editFileInputRef = useRef<HTMLInputElement>(null)
 
+  // 여행 삭제 관련 상태
+  const [deletingTripId, setDeletingTripId] = useState<number | null>(null)
+  const [showDeleteModal, setShowDeleteModal] = useState(false)
+
+  // 포스트 삭제 확인 모달 상태
+  const [deletingPostId, setDeletingPostId] = useState<number | null>(null)
+  const [showPostDeleteModal, setShowPostDeleteModal] = useState(false)
+
+  // 저장된 장소 삭제 확인 모달 상태
+  const [deletingSavedLocationId, setDeletingSavedLocationId] = useState<number | null>(null)
+  const [showSavedLocationDeleteModal, setShowSavedLocationDeleteModal] = useState(false)
+
+  // 토스트 메시지 상태
+  const [toast, setToast] = useState<{
+    show: boolean
+    message: string
+    type: 'success' | 'error' | 'info'
+  }>({
+    show: false,
+    message: '',
+    type: 'info'
+  })
+
   const router = useRouter()
   const { data: session, status } = useSession()
+
+  // 토스트 메시지 함수들
+  const showToast = (message: string, type: 'success' | 'error' | 'info' = 'info') => {
+    setToast({ show: true, message, type })
+    setTimeout(() => {
+      setToast({ show: false, message: '', type: 'info' })
+    }, 2000) // 3초 후 자동 사라짐
+  }
+
+  const hideToast = () => {
+    setToast({ show: false, message: '', type: 'info' })
+  }
 
   // 사용자 프로필 정보 가져오기
   const fetchUserProfile = useCallback(async () => {
@@ -315,7 +350,7 @@ export default function ProfilePage() {
   // 프로필 이미지 업로드
   const handleProfileImageUpload = async () => {
     if (!selectedImage || !session?.user?.id) {
-      alert('업로드 취소: 이미지 또는 세션 없음')
+      showToast('업로드 취소: 이미지 또는 세션 없음', 'error')
       return
     }
 
@@ -345,14 +380,14 @@ export default function ProfilePage() {
 
       const result = await response.json()
 
-      alert('프로필 이미지가 업데이트되었습니다!')
+      showToast('프로필 이미지가 업데이트되었습니다!', 'success')
       setSelectedImage(null)
 
       // 프로필 데이터 다시 가져오기 (페이지 새로고침 없이)
       await fetchUserProfile()
     } catch (error: any) {
       console.error('프로필 이미지 업데이트 오류:', error)
-      alert(`이미지 업데이트에 실패했습니다: ${error.message}`)
+      showToast(`이미지 업데이트에 실패했습니다: ${error.message}`, 'error')
     } finally {
       setIsUploadingImage(false)
     }
@@ -387,11 +422,11 @@ export default function ProfilePage() {
 
       const result = await response.json()
       console.log('기본 정보 업데이트 성공:', result)
-      alert('기본 정보가 업데이트되었습니다!')
+      showToast('기본 정보가 업데이트되었습니다!', 'success')
 
     } catch (error: any) {
       console.error('기본 정보 업데이트 오류:', error)
-      alert(`기본 정보 업데이트에 실패했습니다: ${error.message}`)
+      showToast(`기본 정보 업데이트에 실패했습니다: ${error.message}`, 'error')
     } finally {
       setIsUpdatingBasicInfo(false)
     }
@@ -426,14 +461,14 @@ export default function ProfilePage() {
       }
 
       const result = await response.json()
-      alert('여행 취향이 업데이트되었습니다!')
+      showToast('여행 취향이 업데이트되었습니다!', 'success')
 
       // 프로필 정보 다시 가져오기 (여행 취향 정보 포함)
       await fetchUserProfile()
 
     } catch (error: any) {
       console.error('여행 취향 업데이트 오류:', error)
-      alert(`여행 취향 업데이트에 실패했습니다: ${error.message}`)
+      showToast(`여행 취향 업데이트에 실패했습니다: ${error.message}`, 'error')
     } finally {
       setIsUpdatingPreferences(false)
     }
@@ -511,22 +546,26 @@ export default function ProfilePage() {
         )
       )
 
-      alert('포스트가 수정되었습니다!')
+      showToast('포스트가 수정되었습니다!', 'success')
       handleCancelEdit()
 
     } catch (error: any) {
       console.error('포스트 수정 오류:', error)
-      alert(`포스트 수정에 실패했습니다: ${error.message}`)
+      showToast(`포스트 수정에 실패했습니다: ${error.message}`, 'error')
     } finally {
       setIsUpdatingPost(false)
     }
   }
 
-  // 포스트 삭제
-  const handleDeletePost = async (postId: number) => {
-    if (!session) return
+  // 포스트 삭제 확인 함수
+  const confirmDeletePost = (postId: number) => {
+    setDeletingPostId(postId)
+    setShowPostDeleteModal(true)
+  }
 
-    if (!confirm('정말로 이 포스트를 삭제하시겠습니까?')) return
+  // 포스트 삭제 실행 함수
+  const executeDeletePost = async () => {
+    if (!deletingPostId || !session) return
 
     try {
       const headers: any = {
@@ -537,7 +576,7 @@ export default function ProfilePage() {
         headers['Authorization'] = `Bearer ${(session as any).backendToken}`
       }
 
-      const response = await fetch(`/api/proxy/api/v1/posts/${postId}`, {
+      const response = await fetch(`/api/proxy/api/v1/posts/${deletingPostId}`, {
         method: 'DELETE',
         headers: headers
       })
@@ -548,13 +587,22 @@ export default function ProfilePage() {
       }
 
       // 포스트 목록에서 제거
-      setPosts(prevPosts => prevPosts.filter(post => post.id !== postId))
-      alert('포스트가 삭제되었습니다!')
+      setPosts(prevPosts => prevPosts.filter(post => post.id !== deletingPostId))
+      showToast('포스트가 삭제되었습니다!', 'success')
 
     } catch (error: any) {
       console.error('포스트 삭제 오류:', error)
-      alert(`포스트 삭제에 실패했습니다: ${error.message}`)
+      showToast(`포스트 삭제에 실패했습니다: ${error.message}`, 'error')
+    } finally {
+      setShowPostDeleteModal(false)
+      setDeletingPostId(null)
     }
+  }
+
+  // 포스트 삭제 취소 함수
+  const cancelDeletePost = () => {
+    setShowPostDeleteModal(false)
+    setDeletingPostId(null)
   }
 
   // 로그아웃 핸들러
@@ -572,7 +620,7 @@ export default function ProfilePage() {
   // 여행 카드 클릭 핸들러
   const handleTripClick = (trip: Trip) => {
     if (!trip.places || trip.places.length === 0) {
-      alert('이 여행에는 저장된 장소가 없습니다.')
+      showToast('이 여행에는 저장된 장소가 없습니다.', 'info')
       return
     }
 
@@ -625,22 +673,26 @@ export default function ProfilePage() {
 
 
 
-  // 저장된 장소 삭제 함수
-  const handleDeleteSavedLocation = async (locationId: number) => {
+  // 저장된 장소 삭제 확인 함수
+  const confirmDeleteSavedLocation = (locationId: number) => {
+    setDeletingSavedLocationId(locationId)
+    setShowSavedLocationDeleteModal(true)
+  }
+
+  // 저장된 장소 삭제 실행 함수
+  const executeDeleteSavedLocation = async () => {
+    if (!deletingSavedLocationId) return
+
     try {
       const token = getToken()
       
       if (!token) {
-        alert('로그인이 필요합니다.')
-        return
-      }
-      
-      if (!confirm('저장된 장소를 삭제하시겠습니까?')) {
+        showToast('로그인이 필요합니다.', 'error')
         return
       }
       
       const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
-      const response = await fetch(`${API_BASE_URL}/api/v1/saved-locations/${locationId}`, {
+      const response = await fetch(`${API_BASE_URL}/api/v1/saved-locations/${deletingSavedLocationId}`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`
@@ -649,14 +701,76 @@ export default function ProfilePage() {
       
       if (response.ok) {
         // 삭제 성공 시 목록에서 해당 장소 제거
-        setSavedLocations(prev => prev.filter(location => location.id !== locationId))
+        setSavedLocations(prev => prev.filter(location => location.id !== deletingSavedLocationId))
+        showToast('저장된 장소가 삭제되었습니다.', 'success')
       } else {
-        alert('삭제에 실패했습니다.')
+        showToast('삭제에 실패했습니다.', 'error')
       }
     } catch (error) {
       console.error('저장된 장소 삭제 중 오류:', error)
-      alert('삭제 중 오류가 발생했습니다.')
+      showToast('삭제 중 오류가 발생했습니다.', 'error')
+    } finally {
+      setShowSavedLocationDeleteModal(false)
+      setDeletingSavedLocationId(null)
     }
+  }
+
+  // 저장된 장소 삭제 취소 함수
+  const cancelDeleteSavedLocation = () => {
+    setShowSavedLocationDeleteModal(false)
+    setDeletingSavedLocationId(null)
+  }
+
+  // 여행 삭제 함수
+  const handleDeleteTrip = async (tripId: number) => {
+    try {
+      const token = getToken()
+      
+      if (!token) {
+        showToast('로그인이 필요합니다.', 'error')
+        return
+      }
+      
+      const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
+      const response = await fetch(`${API_BASE_URL}/api/v1/trips/${tripId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      })
+      
+      if (response.ok) {
+        // 삭제 성공 시 목록에서 해당 여행 제거
+        setTrips(prev => prev.filter(trip => trip.id !== tripId))
+        showToast('여행 일정이 삭제되었습니다.', 'success')
+      } else {
+        showToast('삭제에 실패했습니다.', 'error')
+      }
+    } catch (error) {
+      console.error('여행 삭제 중 오류:', error)
+      showToast('삭제 중 오류가 발생했습니다.', 'error')
+    }
+  }
+
+  // 여행 삭제 확인 함수
+  const confirmDeleteTrip = (tripId: number) => {
+    setDeletingTripId(tripId)
+    setShowDeleteModal(true)
+  }
+
+  // 여행 삭제 실행 함수
+  const executeDeleteTrip = async () => {
+    if (deletingTripId) {
+      await handleDeleteTrip(deletingTripId)
+      setShowDeleteModal(false)
+      setDeletingTripId(null)
+    }
+  }
+
+  // 여행 삭제 취소 함수
+  const cancelDeleteTrip = () => {
+    setShowDeleteModal(false)
+    setDeletingTripId(null)
   }
 
 
@@ -690,8 +804,8 @@ export default function ProfilePage() {
                 className="bg-gray-800 p-4 rounded-2xl relative cursor-pointer hover:bg-gray-750 transition-colors"
                 onClick={() => handleTripClick(trip)}
               >
-                {/* 상태 표시 - 모든 카드에 표시 */}
-                <div className="absolute top-4 right-4">
+                {/* 상태 표시와 휴지통 버튼 - 오른쪽 상단 */}
+                <div className="absolute top-4 right-4 flex items-center space-x-2">
                   <span className={`px-2 py-1 rounded-full text-xs flex items-center text-white ${
                     trip.status === 'active' ? 'bg-red-500' : 
                     trip.status === 'completed' ? 'bg-gray-500' : 
@@ -701,6 +815,20 @@ export default function ProfilePage() {
                     {trip.status === 'completed' && '✓ 완료됨'}
                     {trip.status === 'planned' && '📋 예정됨'}
                   </span>
+                  
+                  {/* 휴지통 버튼 */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation() // 카드 클릭 이벤트 방지
+                      confirmDeleteTrip(trip.id)
+                    }}
+                    className="text-red-400 hover:text-red-300 transition-colors p-1 hover:bg-red-900 rounded"
+                    title="일정 삭제"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                  </button>
                 </div>
                 
                 {/* 여행 제목 */}
@@ -825,7 +953,7 @@ export default function ProfilePage() {
                         </svg>
                       </button>
                       <button
-                        onClick={() => handleDeletePost(post.id)}
+                        onClick={() => confirmDeletePost(post.id)}
                         className="text-red-400 hover:text-red-300 transition-colors"
                         title="삭제"
                       >
@@ -871,7 +999,7 @@ export default function ProfilePage() {
                       </p>
                     </div>
                     <button 
-                      onClick={() => handleDeleteSavedLocation(location.id)}
+                      onClick={() => confirmDeleteSavedLocation(location.id)}
                       className="text-red-400 hover:text-red-300 transition-colors p-1"
                       title="저장된 장소 삭제"
                     >
@@ -1301,6 +1429,162 @@ export default function ProfilePage() {
                 </button>
               </div>
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* Trip Delete Confirmation Modal */}
+      {showDeleteModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
+            <div className="p-6">
+              <div className="text-center mb-6">
+                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
+                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-white mb-2">일정을 삭제하시겠습니까?</h3>
+                <p className="text-gray-400 text-sm">
+                  삭제된 일정은 복구할 수 없습니다.<br/>
+                  정말로 삭제하시겠습니까?
+                </p>
+              </div>
+
+              {/* 버튼 */}
+              <div className="flex space-x-3">
+                <button
+                  onClick={cancelDeleteTrip}
+                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={executeDeleteTrip}
+                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Post Delete Confirmation Modal */}
+      {showPostDeleteModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
+            <div className="p-6">
+              <div className="text-center mb-6">
+                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
+                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-white mb-2">포스트를 삭제하시겠습니까?</h3>
+                <p className="text-gray-400 text-sm">
+                  삭제된 포스트는 복구할 수 없습니다.<br/>
+                  정말로 삭제하시겠습니까?
+                </p>
+              </div>
+
+              {/* 버튼 */}
+              <div className="flex space-x-3">
+                <button
+                  onClick={cancelDeletePost}
+                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={executeDeletePost}
+                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Saved Location Delete Confirmation Modal */}
+      {showSavedLocationDeleteModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
+            <div className="p-6">
+              <div className="text-center mb-6">
+                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
+                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-white mb-2">저장된 장소를 삭제하시겠습니까?</h3>
+                <p className="text-gray-400 text-sm">
+                  삭제된 장소는 복구할 수 없습니다.<br/>
+                  정말로 삭제하시겠습니까?
+                </p>
+              </div>
+
+              {/* 버튼 */}
+              <div className="flex space-x-3">
+                <button
+                  onClick={cancelDeleteSavedLocation}
+                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={executeDeleteSavedLocation}
+                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                >
+                  삭제
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Toast Notification */}
+      {toast.show && (
+        <div className="fixed top-4 left-4 right-4 z-50 flex justify-center">
+          <div className={`
+            flex items-center px-6 py-3 rounded-lg shadow-lg text-white font-medium max-w-sm
+            transform transition-all duration-300 ease-in-out
+            ${toast.type === 'success' ? 'bg-green-600' : 
+              toast.type === 'error' ? 'bg-red-600' : 
+              'bg-blue-600'}
+            animate-in slide-in-from-top-4 fade-in
+          `}>
+            <div className="mr-3">
+              {toast.type === 'success' && (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+              {toast.type === 'error' && (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              )}
+              {toast.type === 'info' && (
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+              )}
+            </div>
+            <span className="flex-1 text-sm">{toast.message}</span>
+            <button
+              onClick={hideToast}
+              className="ml-3 text-white hover:text-gray-200 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
           </div>
         </div>
       )}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -597,7 +597,8 @@ export default function ProfilePage() {
       baseAttraction: 'general',
       source: 'profile',
       tripTitle: trip.title,
-      tripDescription: trip.description || ''
+      tripDescription: trip.description || '',
+      tripId: trip.id.toString()
     })
     
     // map 페이지로 이동

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -27,6 +27,7 @@ interface TripPlace {
   }
   cityName?: string
   isPinned?: boolean
+  isLocked?: boolean
 }
 
 interface Trip {
@@ -629,6 +630,12 @@ export default function ProfilePage() {
     const dayNumbers = trip.places.map(place => place.dayNumber.toString())
     const sourceTables = trip.places.map(place => place.table_name)
     
+    // 잠금 상태 정보 (전체 식별자_dayNumber 형태로 잠금된 장소들의 키)
+    const lockedPlaceKeys = trip.places
+      .filter(place => place.isLocked)
+      .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
+    console.log('lockedPlaceKeys:', lockedPlaceKeys)
+    
     // 날짜 차이 계산
     const startDate = new Date(trip.start_date)
     const endDate = new Date(trip.end_date)
@@ -646,7 +653,8 @@ export default function ProfilePage() {
       source: 'profile',
       tripTitle: trip.title,
       tripDescription: trip.description || '',
-      tripId: trip.id.toString()
+      tripId: trip.id.toString(),
+      ...(lockedPlaceKeys.length > 0 && { lockedPlaces: lockedPlaceKeys.join(',') })
     })
     
     // map 페이지로 이동 (보기 모드 - long press 불가)
@@ -664,6 +672,12 @@ export default function ProfilePage() {
     const placeIds = trip.places.map(place => `${place.table_name}_${place.id}`)
     const dayNumbers = trip.places.map(place => place.dayNumber.toString())
     const sourceTables = trip.places.map(place => place.table_name)
+    
+    // 잠금 상태 정보 (전체 식별자_dayNumber 형태로 잠금된 장소들의 키)
+    const lockedPlaceKeys = trip.places
+      .filter(place => place.isLocked)
+      .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
+    console.log('lockedPlaceKeys:', lockedPlaceKeys)
     
     // 날짜 차이 계산
     const startDate = new Date(trip.start_date)
@@ -683,7 +697,8 @@ export default function ProfilePage() {
       tripTitle: trip.title,
       tripDescription: trip.description || '',
       tripId: trip.id.toString(),
-      editMode: 'true' // 편집 모드 플래그 추가
+      editMode: 'true', // 편집 모드 플래그 추가
+      ...(lockedPlaceKeys.length > 0 && { lockedPlaces: lockedPlaceKeys.join(',') })
     })
     
     // map 페이지로 이동 (편집 모드 - long press 가능)

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -594,7 +594,10 @@ export default function ProfilePage() {
       startDate: trip.start_date,
       endDate: trip.end_date,
       days: daysDiff.toString(),
-      baseAttraction: 'general'
+      baseAttraction: 'general',
+      source: 'profile',
+      tripTitle: trip.title,
+      tripDescription: trip.description || ''
     })
     
     // map 페이지로 이동

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -634,7 +634,6 @@ export default function ProfilePage() {
     const lockedPlaceKeys = trip.places
       .filter(place => place.isLocked)
       .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
-    console.log('lockedPlaceKeys:', lockedPlaceKeys)
     
     // 날짜 차이 계산
     const startDate = new Date(trip.start_date)
@@ -677,7 +676,6 @@ export default function ProfilePage() {
     const lockedPlaceKeys = trip.places
       .filter(place => place.isLocked)
       .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
-    console.log('lockedPlaceKeys:', lockedPlaceKeys)
     
     // 날짜 차이 계산
     const startDate = new Date(trip.start_date)

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -617,7 +617,7 @@ export default function ProfilePage() {
     }
   }
 
-  // 여행 카드 클릭 핸들러
+  // 여행 카드 클릭 핸들러 (보기 모드)
   const handleTripClick = (trip: Trip) => {
     if (!trip.places || trip.places.length === 0) {
       showToast('이 여행에는 저장된 장소가 없습니다.', 'info')
@@ -634,7 +634,7 @@ export default function ProfilePage() {
     const endDate = new Date(trip.end_date)
     const daysDiff = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1
     
-    // URL 파라미터 생성
+    // URL 파라미터 생성 (보기 모드)
     const params = new URLSearchParams({
       places: placeIds.join(','),
       dayNumbers: dayNumbers.join(','),
@@ -649,7 +649,44 @@ export default function ProfilePage() {
       tripId: trip.id.toString()
     })
     
-    // map 페이지로 이동
+    // map 페이지로 이동 (보기 모드 - long press 불가)
+    router.push(`/map?${params.toString()}`)
+  }
+
+  // 여행 편집 버튼 클릭 핸들러 (편집 모드)
+  const handleEditTripClick = (trip: Trip) => {
+    if (!trip.places || trip.places.length === 0) {
+      showToast('이 여행에는 저장된 장소가 없습니다.', 'info')
+      return
+    }
+
+    // DB 구조에 맞게 데이터 변환: table_name + "_" + id 형태로 조합
+    const placeIds = trip.places.map(place => `${place.table_name}_${place.id}`)
+    const dayNumbers = trip.places.map(place => place.dayNumber.toString())
+    const sourceTables = trip.places.map(place => place.table_name)
+    
+    // 날짜 차이 계산
+    const startDate = new Date(trip.start_date)
+    const endDate = new Date(trip.end_date)
+    const daysDiff = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1
+    
+    // URL 파라미터 생성 (편집 모드)
+    const params = new URLSearchParams({
+      places: placeIds.join(','),
+      dayNumbers: dayNumbers.join(','),
+      sourceTables: sourceTables.join(','),
+      startDate: trip.start_date,
+      endDate: trip.end_date,
+      days: daysDiff.toString(),
+      baseAttraction: 'general',
+      source: 'profile',
+      tripTitle: trip.title,
+      tripDescription: trip.description || '',
+      tripId: trip.id.toString(),
+      editMode: 'true' // 편집 모드 플래그 추가
+    })
+    
+    // map 페이지로 이동 (편집 모드 - long press 가능)
     router.push(`/map?${params.toString()}`)
   }
 
@@ -804,7 +841,7 @@ export default function ProfilePage() {
                 className="bg-gray-800 p-4 rounded-2xl relative cursor-pointer hover:bg-gray-750 transition-colors"
                 onClick={() => handleTripClick(trip)}
               >
-                {/* 상태 표시와 휴지통 버튼 - 오른쪽 상단 */}
+                {/* 상태 표시와 버튼들 - 오른쪽 상단 */}
                 <div className="absolute top-4 right-4 flex items-center space-x-2">
                   <span className={`px-2 py-1 rounded-full text-xs flex items-center text-white ${
                     trip.status === 'active' ? 'bg-red-500' : 
@@ -815,6 +852,20 @@ export default function ProfilePage() {
                     {trip.status === 'completed' && '✓ 완료됨'}
                     {trip.status === 'planned' && '📋 예정됨'}
                   </span>
+                  
+                  {/* 편집 버튼 */}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation() // 카드 클릭 이벤트 방지
+                      handleEditTripClick(trip)
+                    }}
+                    className="text-blue-400 hover:text-blue-300 transition-colors p-1 hover:bg-blue-900 rounded"
+                    title="일정 편집"
+                  >
+                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </button>
                   
                   {/* 휴지통 버튼 */}
                   <button

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -866,20 +866,6 @@ export default function ProfilePage() {
                     {trip.status === 'planned' && '📋 예정됨'}
                   </span>
                   
-                  {/* 편집 버튼 */}
-                  <button
-                    onClick={(e) => {
-                      e.stopPropagation() // 카드 클릭 이벤트 방지
-                      handleEditTripClick(trip)
-                    }}
-                    className="text-blue-400 hover:text-blue-300 transition-colors p-1 hover:bg-blue-900 rounded"
-                    title="일정 편집"
-                  >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                    </svg>
-                  </button>
-                  
                   {/* 휴지통 버튼 */}
                   <button
                     onClick={(e) => {

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1487,32 +1487,28 @@ export default function ProfilePage() {
       {/* Trip Delete Confirmation Modal */}
       {showDeleteModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
-            <div className="p-6">
-              <div className="text-center mb-6">
-                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </div>
-                <h3 className="text-lg font-semibold text-white mb-2">일정을 삭제하시겠습니까?</h3>
-                <p className="text-gray-400 text-sm">
-                  삭제된 일정은 복구할 수 없습니다.<br/>
-                  정말로 삭제하시겠습니까?
-                </p>
+          <div className="relative bg-[#0B1220] border border-[#1F3C7A]/50 rounded-2xl p-6 mx-4 max-w-sm w-full shadow-2xl">
+            <div className="text-center">
+              <div className="mx-auto w-12 h-12 bg-red-500/20 rounded-full flex items-center justify-center mb-4">
+                <svg className="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
               </div>
-
-              {/* 버튼 */}
+              <h3 className="text-lg font-semibold text-white mb-2">여행 일정 삭제 확인</h3>
+              <p className="text-[#94A9C9] text-sm mb-6 leading-relaxed">
+                여행 일정을 삭제하시겠습니까?<br/>
+                <span className="text-[#6FA0E6] text-xs mt-2 block">삭제된 일정은 복구할 수 없습니다.</span>
+              </p>
               <div className="flex space-x-3">
                 <button
                   onClick={cancelDeleteTrip}
-                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-[#1F3C7A]/30 hover:bg-[#1F3C7A]/50 border border-[#1F3C7A]/50 hover:border-[#1F3C7A]/70 rounded-xl text-[#94A9C9] hover:text-white transition-all duration-200"
                 >
                   취소
                 </button>
                 <button
                   onClick={executeDeleteTrip}
-                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-red-500/20 hover:bg-red-500/30 border border-red-500/50 hover:border-red-500/70 rounded-xl text-red-400 hover:text-red-300 transition-all duration-200 font-medium"
                 >
                   삭제
                 </button>
@@ -1525,32 +1521,28 @@ export default function ProfilePage() {
       {/* Post Delete Confirmation Modal */}
       {showPostDeleteModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
-            <div className="p-6">
-              <div className="text-center mb-6">
-                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                  </svg>
-                </div>
-                <h3 className="text-lg font-semibold text-white mb-2">포스트를 삭제하시겠습니까?</h3>
-                <p className="text-gray-400 text-sm">
-                  삭제된 포스트는 복구할 수 없습니다.<br/>
-                  정말로 삭제하시겠습니까?
-                </p>
+          <div className="relative bg-[#0B1220] border border-[#1F3C7A]/50 rounded-2xl p-6 mx-4 max-w-sm w-full shadow-2xl">
+            <div className="text-center">
+              <div className="mx-auto w-12 h-12 bg-red-500/20 rounded-full flex items-center justify-center mb-4">
+                <svg className="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
               </div>
-
-              {/* 버튼 */}
+              <h3 className="text-lg font-semibold text-white mb-2">포스트 삭제 확인</h3>
+              <p className="text-[#94A9C9] text-sm mb-6 leading-relaxed">
+                포스트를 삭제하시겠습니까?<br/>
+                <span className="text-[#6FA0E6] text-xs mt-2 block">삭제된 포스트는 복구할 수 없습니다.</span>
+              </p>
               <div className="flex space-x-3">
                 <button
                   onClick={cancelDeletePost}
-                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-[#1F3C7A]/30 hover:bg-[#1F3C7A]/50 border border-[#1F3C7A]/50 hover:border-[#1F3C7A]/70 rounded-xl text-[#94A9C9] hover:text-white transition-all duration-200"
                 >
                   취소
                 </button>
                 <button
                   onClick={executeDeletePost}
-                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-red-500/20 hover:bg-red-500/30 border border-red-500/50 hover:border-red-500/70 rounded-xl text-red-400 hover:text-red-300 transition-all duration-200 font-medium"
                 >
                   삭제
                 </button>
@@ -1563,33 +1555,29 @@ export default function ProfilePage() {
       {/* Saved Location Delete Confirmation Modal */}
       {showSavedLocationDeleteModal && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-2xl w-full max-w-sm">
-            <div className="p-6">
-              <div className="text-center mb-6">
-                <div className="mx-auto w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mb-4">
-                  <svg className="w-8 h-8 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-                  </svg>
-                </div>
-                <h3 className="text-lg font-semibold text-white mb-2">저장된 장소를 삭제하시겠습니까?</h3>
-                <p className="text-gray-400 text-sm">
-                  삭제된 장소는 복구할 수 없습니다.<br/>
-                  정말로 삭제하시겠습니까?
-                </p>
+          <div className="relative bg-[#0B1220] border border-[#1F3C7A]/50 rounded-2xl p-6 mx-4 max-w-sm w-full shadow-2xl">
+            <div className="text-center">
+              <div className="mx-auto w-12 h-12 bg-red-500/20 rounded-full flex items-center justify-center mb-4">
+                <svg className="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                </svg>
               </div>
-
-              {/* 버튼 */}
+              <h3 className="text-lg font-semibold text-white mb-2">저장된 장소 삭제 확인</h3>
+              <p className="text-[#94A9C9] text-sm mb-6 leading-relaxed">
+                저장된 장소를 삭제하시겠습니까?<br/>
+                <span className="text-[#6FA0E6] text-xs mt-2 block">삭제된 장소는 복구할 수 없습니다.</span>
+              </p>
               <div className="flex space-x-3">
                 <button
                   onClick={cancelDeleteSavedLocation}
-                  className="flex-1 py-3 px-4 bg-gray-600 text-white rounded-lg hover:bg-gray-500 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-[#1F3C7A]/30 hover:bg-[#1F3C7A]/50 border border-[#1F3C7A]/50 hover:border-[#1F3C7A]/70 rounded-xl text-[#94A9C9] hover:text-white transition-all duration-200"
                 >
                   취소
                 </button>
                 <button
                   onClick={executeDeleteSavedLocation}
-                  className="flex-1 py-3 px-4 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+                  className="flex-1 py-2.5 px-4 bg-red-500/20 hover:bg-red-500/30 border border-red-500/50 hover:border-red-500/70 rounded-xl text-red-400 hover:text-red-300 transition-all duration-200 font-medium"
                 >
                   삭제
                 </button>


### PR DESCRIPTION
# Pull Request - 여행 일정 관리 기능 종합 개선

## 개요
여행 일정의 편집, 저장, 삭제 기능을 전면 개선

## 주요 기능

### 장소 잠금 기능
- **일정 저장 시 잠금 상태 보존**: 사용자가 설정한 장소 잠금이 DB에 저장되어 일정 불러올 때 유지됨
- **최적화 경로 시 순서 보호**: 잠긴 장소는 경로 최적화 시에도 순서가 변경되지 않음
- **편집 모드별 잠금 제어**: 프로필에서 보기 시 잠금 해제 불가, 편집 모드에서만 잠금/해제 가능

### 일정 편집 시스템
- **인라인 편집**: 프로필에서 일정 제목/설명을 바로 편집 가능
- **편집 모드 토글**: 보기 모드 ↔ 편집 모드 자유 전환
- **실시간 업데이트**: 편집 내용이 즉시 서버에 반영되고 UI 업데이트

### 상황별 인터랙션 제어
- **프로필 → 지도 (보기 모드)**: 드래그/롱프레스 비활성화, 검색/필터 숨김
- **프로필 → 지도 (편집 모드)**: 모든 편집 기능 활성화
- **새 일정 생성**: 기존과 동일한 전체 기능 제공

### 삭제 기능 개선
- **확인 모달**: 일정, 포스트, 저장된 장소 삭제 시 확인 모달 표시
- **안전한 삭제**: 실수 방지를 위한 2단계 삭제 확인
- **즉시 UI 반영**: 삭제 후 목록에서 즉시 제거

### 일정 보기/편집 플로우
- **원클릭 보기**: 저장된 일정 카드 클릭으로 지도에서 바로 확인
- **편집 버튼**: 별도 편집 버튼으로 편집 모드 진입
- **상태 표시**: 진행중/완료/계획됨 상태별 시각적 구분

### 상태 관리
- **편집 모드 상태**: `isEditMode` 상태로 UI 동작 제어
- **잠금 상태 복원**: URL 파라미터를 통한 잠금 상태 전달 및 복원
- **토스트 알림**: 성공/오류 상황에 대한 사용자 피드백

## UX/UI 개선

### 프로필 페이지
- **일정 카드 개선**: 제목/설명 인라인 편집, 편집/삭제 버튼 추가
- **확인 모달**: 깔끔한 디자인의 삭제 확인 모달
- **토스트 알림**: 작업 결과에 대한 즉각적인 피드백

### 지도 페이지
- **조건부 UI**: 프로필에서 온 경우 검색바/필터 숨김
- **편집 버튼**: 편집 완료/시작 토글 버튼
- **롱프레스 제어**: 상황에 맞는 드래그 기능 활성화/비활성화

## 파일 변경사항

### Backend
- `backend/routers/trips.py`: 일정 업데이트 로직 개선, 잠금 상태 처리

### Frontend
- `frontend/src/app/api.ts`: updateTrip API 함수 추가
- `frontend/src/app/map/page.tsx`: 편집 모드, 상황별 UI 제어, 잠금 상태 관리
- `frontend/src/app/profile/page.tsx`: 일정 편집, 삭제 확인 모달, 토스트 알림