### PR TITLE
Feat/edit select day

### DIFF
--- a/frontend/src/app/itinerary/[attractionId]/page.tsx
+++ b/frontend/src/app/itinerary/[attractionId]/page.tsx
@@ -100,7 +100,13 @@ export default function ItineraryBuilder({ params }: ItineraryBuilderProps) {
     }
 
     const dates = []
-    const startDate = new Date(startDateParam)
+    // 한국 시간 기준으로 날짜 생성 (UTC 해석 방지)
+    const createLocalDate = (dateString: string) => {
+      const [year, month, day] = dateString.split('-').map(Number)
+      return new Date(year, month - 1, day) // month는 0부터 시작
+    }
+    
+    const startDate = createLocalDate(startDateParam)
     const dayCount = parseInt(daysParam)
 
     for (let i = 0; i < dayCount; i++) {
@@ -782,8 +788,17 @@ export default function ItineraryBuilder({ params }: ItineraryBuilderProps) {
     const selectedPlaceIds = allSelectedPlaces.map(place => place.id).join(',')
     const dayNumbers = allSelectedPlaces.map(place => place.dayNumber || 1).join(',')
     const sourceTables = allSelectedPlaces.map(place => place.sourceTable || 'unknown').join(',')
-    const startDate = dateRange[0].toISOString().split('T')[0]
-    const endDate = dateRange[dateRange.length - 1].toISOString().split('T')[0]
+    
+    // 로컬 시간 기준으로 YYYY-MM-DD 포맷팅 (UTC 변환 없이)
+    const formatLocalDate = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+    
+    const startDate = formatLocalDate(dateRange[0])
+    const endDate = formatLocalDate(dateRange[dateRange.length - 1])
 
     const queryParams = new URLSearchParams({
       places: selectedPlaceIds,
@@ -1054,7 +1069,7 @@ export default function ItineraryBuilder({ params }: ItineraryBuilderProps) {
                   <div className="text-center">
                     <div className="font-semibold">Day {dayNumber}</div>
                     <div className="text-xs opacity-80">
-                      {date.getMonth() + 1}/{date.getDate() + 1}
+                      {date.getMonth() + 1}/{date.getDate()}
                     </div>
                     {placesForDay > 0 && (
                       <div className={`text-xs mt-1 ${isSelected ? 'text-white' : 'text-[#3E68FF]'}`}>

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1871,8 +1871,12 @@ export default function MapPage() {
               {/* 여행 정보 */}
               {startDateParam && endDateParam && daysParam && (
                 <div 
-                  className="bg-[#12345D]/50 rounded-2xl p-4 mb-6 cursor-pointer hover:bg-[#12345D]/70 transition-colors"
-                  onClick={() => {
+                  className={`bg-[#12345D]/50 rounded-2xl p-4 mb-6 transition-colors ${
+                    (!isFromProfile || isEditMode) 
+                      ? 'cursor-pointer hover:bg-[#12345D]/70' 
+                      : 'cursor-default'
+                  }`}
+                  onClick={(!isFromProfile || isEditMode) ? () => {
                     // 한국 시간 기준으로 날짜 생성 (UTC 해석 방지)
                     const createLocalDate = (dateString: string) => {
                       const [year, month, day] = dateString.split('-').map(Number);
@@ -1886,8 +1890,8 @@ export default function MapPage() {
                       currentMonth: createLocalDate(startDateParam),
                       isSelectingRange: false
                     })
-                  }}
-                  title="클릭해서 여행 날짜 수정"
+                  } : undefined}
+                  title={(!isFromProfile || isEditMode) ? "클릭해서 여행 날짜 수정" : ""}
                 >
                   <div className="flex items-center justify-between">
                     <div>
@@ -1906,11 +1910,14 @@ export default function MapPage() {
                       <p className="text-[#6FA0E6] text-sm mb-1">총 일수</p>
                       <p className="text-white font-semibold">{daysParam}일</p>
                     </div>
-                    <div className="ml-4 text-[#6FA0E6]">
-                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                      </svg>
-                    </div>
+                    {/* 편집 아이콘 - 편집 가능할 때만 표시 */}
+                    {(!isFromProfile || isEditMode) && (
+                      <div className="ml-4 text-[#6FA0E6]">
+                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                        </svg>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1892,9 +1892,17 @@ export default function MapPage() {
                   return acc;
                 }, {});
 
-                const sortedDays = Object.keys(groupedPlaces).map(Number).sort((a, b) => a - b);
+                // 날짜 범위가 있으면 모든 날짜를 표시, 없으면 기존 로직 사용
+                let allDays: number[] = [];
+                if (daysParam) {
+                  // 1일차부터 총 일수까지 모든 날짜 생성
+                  allDays = Array.from({length: parseInt(daysParam)}, (_, i) => i + 1);
+                } else {
+                  // 기존 로직: 장소가 있는 날짜만
+                  allDays = Object.keys(groupedPlaces).map(Number).sort((a, b) => a - b);
+                }
 
-                return sortedDays.map(day => (
+                return allDays.map(day => (
                   <div key={day} className={`mb-6 rounded-2xl transition-all duration-300 ${
                     highlightedDay === day ? 'bg-[#3E68FF]/10 border-2 border-[#3E68FF]/30 p-4' : 'p-2'
                   }`}>
@@ -1926,7 +1934,7 @@ export default function MapPage() {
                       </div>
                       
                       {/* 경로 버튼들 (2개 이상일 때만 표시) */}
-                      {groupedPlaces[day].length >= 2 && (
+                      {groupedPlaces[day] && groupedPlaces[day].length >= 2 && (
                         <div className="flex items-center space-x-2" onClick={(e) => e.stopPropagation()}>
                           <button
                             onClick={(e) => {
@@ -1961,7 +1969,7 @@ export default function MapPage() {
                     </div>
                     
                     <div className="space-y-3 ml-5">
-                      {groupedPlaces[day].map((place, index) => (
+                      {(groupedPlaces[day] || []).map((place, index) => (
                         <React.Fragment key={`place-container-${place.id}-${day}-${index}`}>
                         <div>
                           {/* 드롭 존 - 위쪽 */}
@@ -2089,7 +2097,7 @@ export default function MapPage() {
                         </div>
 
                         {/* 구간 정보 (마지막 장소가 아닐 때만 표시) */}
-                        {index < groupedPlaces[day].length - 1 && (
+                        {groupedPlaces[day] && index < groupedPlaces[day].length - 1 && (
                           (() => {
                             const nextPlace = groupedPlaces[day][index + 1];
                             const segmentInfo = getRouteSegmentInfo(day, place.id, nextPlace.id);
@@ -2219,16 +2227,24 @@ export default function MapPage() {
                         </React.Fragment>
                       ))}
                       
+                      {/* 일정이 없을 때 안내 메시지 */}
+                      {(!groupedPlaces[day] || groupedPlaces[day].length === 0) && (
+                        <div className="text-center py-8 text-[#94A9C9]">
+                          <p className="text-sm">이 날에는 아직 일정이 없습니다.</p>
+                          <p className="text-xs mt-1">장소를 드래그해서 일정을 추가해보세요.</p>
+                        </div>
+                      )}
+                      
                       {/* 마지막 드롭 존 */}
                       <div
                         data-drop-zone="true"
                         data-day={day}
-                        data-index={groupedPlaces[day].length}
-                        onDragOver={(e) => handleDragOver(e, groupedPlaces[day].length, day)}
+                        data-index={(groupedPlaces[day] || []).length}
+                        onDragOver={(e) => handleDragOver(e, (groupedPlaces[day] || []).length, day)}
                         onDragLeave={handleDragLeave}
-                        onDrop={(e) => handleDrop(e, groupedPlaces[day].length, day)}
+                        onDrop={(e) => handleDrop(e, (groupedPlaces[day] || []).length, day)}
                         className={`h-2 w-full transition-all duration-200 ${
-                          dragOverIndex?.day === day && dragOverIndex?.index === groupedPlaces[day].length && draggedItem 
+                          dragOverIndex?.day === day && dragOverIndex?.index === (groupedPlaces[day] || []).length && draggedItem 
                             ? 'border-t-4 border-[#3E68FF] bg-[#3E68FF]/10 mt-2' 
                             : ''
                         }`}

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -127,6 +127,15 @@ export default function MapPage() {
   const [dragOverIndex, setDragOverIndex] = useState<{day: number, index: number} | null>(null)
   const dragRef = useRef<HTMLDivElement>(null)
   
+  // 날짜 수정 모달 상태
+  const [dateEditModal, setDateEditModal] = useState({
+    isOpen: false,
+    selectedStartDate: null as Date | null,
+    selectedEndDate: null as Date | null,
+    currentMonth: new Date(),
+    isSelectingRange: false
+  })
+
   // Long press 상태
   const [longPressData, setLongPressData] = useState<{
     isLongPressing: boolean,
@@ -1861,7 +1870,25 @@ export default function MapPage() {
               
               {/* 여행 정보 */}
               {startDateParam && endDateParam && daysParam && (
-                <div className="bg-[#12345D]/50 rounded-2xl p-4 mb-6">
+                <div 
+                  className="bg-[#12345D]/50 rounded-2xl p-4 mb-6 cursor-pointer hover:bg-[#12345D]/70 transition-colors"
+                  onClick={() => {
+                    // 한국 시간 기준으로 날짜 생성 (UTC 해석 방지)
+                    const createLocalDate = (dateString: string) => {
+                      const [year, month, day] = dateString.split('-').map(Number);
+                      return new Date(year, month - 1, day); // month는 0부터 시작
+                    };
+                    
+                    setDateEditModal({
+                      isOpen: true,
+                      selectedStartDate: createLocalDate(startDateParam),
+                      selectedEndDate: createLocalDate(endDateParam),
+                      currentMonth: createLocalDate(startDateParam),
+                      isSelectingRange: false
+                    })
+                  }}
+                  title="클릭해서 여행 날짜 수정"
+                >
                   <div className="flex items-center justify-between">
                     <div>
                       <p className="text-[#6FA0E6] text-sm mb-1">여행 기간</p>
@@ -1878,6 +1905,11 @@ export default function MapPage() {
                     <div className="text-right">
                       <p className="text-[#6FA0E6] text-sm mb-1">총 일수</p>
                       <p className="text-white font-semibold">{daysParam}일</p>
+                    </div>
+                    <div className="ml-4 text-[#6FA0E6]">
+                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                      </svg>
                     </div>
                   </div>
                 </div>
@@ -2583,6 +2615,211 @@ export default function MapPage() {
                   }`}
                 >
                   저장하기
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* 날짜 수정 모달 */}
+      {dateEditModal.isOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-[#0B1220] rounded-2xl shadow-xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+            {/* 모달 헤더 */}
+            <div className="p-6 border-b border-[#1F3C7A]/30">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-semibold text-white">여행 날짜 수정</h3>
+                <button
+                  onClick={() => setDateEditModal(prev => ({ ...prev, isOpen: false }))}
+                  className="p-2 hover:bg-[#1F3C7A]/30 rounded-full transition-colors"
+                >
+                  <svg className="w-5 h-5 text-[#94A9C9]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              
+              {/* 선택된 날짜 표시 */}
+              <div className="bg-[#12345D]/50 rounded-lg p-3">
+                <p className="text-[#6FA0E6] text-sm mb-1">선택된 기간</p>
+                <p className="text-white font-semibold">
+                  {dateEditModal.selectedStartDate && dateEditModal.selectedEndDate ? (
+                    `${dateEditModal.selectedStartDate.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })} - ${dateEditModal.selectedEndDate.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })}`
+                  ) : dateEditModal.selectedStartDate ? (
+                    `${dateEditModal.selectedStartDate.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })} - 종료일을 선택하세요`
+                  ) : (
+                    "시작일을 선택하세요"
+                  )}
+                </p>
+                {dateEditModal.selectedStartDate && dateEditModal.selectedEndDate && (
+                  <p className="text-[#94A9C9] text-sm mt-1">
+                    총 {Math.ceil((dateEditModal.selectedEndDate.getTime() - dateEditModal.selectedStartDate.getTime()) / (1000 * 60 * 60 * 24)) + 1}일
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* 달력 */}
+            <div className="px-6 mb-8">
+              <div className="flex items-center justify-between mb-6">
+                <button 
+                  onClick={() => {
+                    const newMonth = new Date(dateEditModal.currentMonth);
+                    newMonth.setMonth(newMonth.getMonth() - 1);
+                    setDateEditModal(prev => ({ ...prev, currentMonth: newMonth }));
+                  }}
+                  className="p-2 hover:bg-[#1F3C7A]/30 rounded-full transition-colors"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                  </svg>
+                </button>
+                <h2 className="text-xl font-semibold text-[#94A9C9]">
+                  {dateEditModal.currentMonth.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long' })}
+                </h2>
+                <button 
+                  onClick={() => {
+                    const newMonth = new Date(dateEditModal.currentMonth);
+                    newMonth.setMonth(newMonth.getMonth() + 1);
+                    setDateEditModal(prev => ({ ...prev, currentMonth: newMonth }));
+                  }}
+                  className="p-2 hover:bg-[#1F3C7A]/30 rounded-full transition-colors"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </div>
+
+              {/* 요일 헤더 */}
+              <div className="grid grid-cols-7 gap-1 mb-2">
+                {['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'].map(day => (
+                  <div key={day} className="text-center text-[#6FA0E6] text-sm font-medium py-2">{day}</div>
+                ))}
+              </div>
+
+              {/* 달력 날짜들 */}
+              <div className="grid grid-cols-7 gap-1">
+                {(() => {
+                  const today = new Date();
+                  today.setHours(0, 0, 0, 0);
+                  const currentMonth = dateEditModal.currentMonth;
+                  const firstDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1);
+                  const lastDay = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0);
+                  const startDate = new Date(firstDay);
+                  
+                  // 월요일을 첫 번째 요일로 설정 (0=일요일, 1=월요일)
+                  const firstDayOfWeek = firstDay.getDay();
+                  const mondayOffset = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1;
+                  startDate.setDate(startDate.getDate() - mondayOffset);
+                  
+                  const days = [];
+                  for (let i = 0; i < 42; i++) {
+                    const day = new Date(startDate);
+                    day.setDate(startDate.getDate() + i);
+                    days.push(day);
+                  }
+                  
+                  return days.map((day) => {
+                    const isCurrentMonth = day.getMonth() === currentMonth.getMonth();
+                    const isPast = day < today;
+                    const isSelected = (dateEditModal.selectedStartDate && 
+                      day.toDateString() === dateEditModal.selectedStartDate.toDateString()) ||
+                      (dateEditModal.selectedEndDate && 
+                      day.toDateString() === dateEditModal.selectedEndDate.toDateString());
+                    const isInRange = dateEditModal.selectedStartDate && dateEditModal.selectedEndDate &&
+                      day >= dateEditModal.selectedStartDate && day <= dateEditModal.selectedEndDate;
+                    
+                    return (
+                      <button
+                        key={day.toISOString()}
+                        disabled={isPast}
+                        onClick={() => {
+                          if (!dateEditModal.selectedStartDate || (dateEditModal.selectedStartDate && dateEditModal.selectedEndDate)) {
+                            // 시작일 선택 또는 새로운 범위 시작
+                            setDateEditModal(prev => ({
+                              ...prev,
+                              selectedStartDate: day,
+                              selectedEndDate: null,
+                              isSelectingRange: true
+                            }));
+                          } else if (day >= dateEditModal.selectedStartDate) {
+                            // 종료일 선택
+                            setDateEditModal(prev => ({
+                              ...prev,
+                              selectedEndDate: day,
+                              isSelectingRange: false
+                            }));
+                          } else {
+                            // 시작일보다 이전 날짜 선택시 새로운 시작일로 설정
+                            setDateEditModal(prev => ({
+                              ...prev,
+                              selectedStartDate: day,
+                              selectedEndDate: null,
+                              isSelectingRange: true
+                            }));
+                          }
+                        }}
+                        className={`aspect-square rounded-full flex items-center justify-center text-sm font-medium transition-all duration-200 
+                          ${!isCurrentMonth 
+                            ? 'text-[#6FA0E6]/20 cursor-not-allowed' 
+                            : isPast 
+                              ? 'text-[#6FA0E6]/20 cursor-not-allowed'
+                              : isSelected
+                                ? 'bg-[#3E68FF] text-white'
+                                : isInRange
+                                  ? 'bg-[#3E68FF]/30 text-white'
+                                  : 'hover:bg-[#1F3C7A]/30 ring-1 ring-transparent hover:ring-[#3E68FF]/50'
+                          } text-[#94A9C9]`}
+                      >
+                        {day.getDate()}
+                      </button>
+                    );
+                  });
+                })()}
+              </div>
+            </div>
+
+            {/* 모달 버튼 */}
+            <div className="px-6 pb-6 pt-0 border-t border-[#1F3C7A]/30">
+              <div className="flex space-x-3 mt-6">
+                <button
+                  onClick={() => setDateEditModal(prev => ({ ...prev, isOpen: false }))}
+                  className="flex-1 py-2.5 px-4 bg-[#1F3C7A]/30 hover:bg-[#1F3C7A]/50 border border-[#1F3C7A]/50 hover:border-[#1F3C7A]/70 rounded-xl text-[#94A9C9] hover:text-white transition-all duration-200"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={() => {
+                    if (dateEditModal.selectedStartDate && dateEditModal.selectedEndDate) {
+                      const daysDiff = Math.ceil((dateEditModal.selectedEndDate.getTime() - dateEditModal.selectedStartDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+                      
+                      // 로컬 시간 기준으로 YYYY-MM-DD 포맷팅 (UTC 변환 없이)
+                      const formatLocalDate = (date: Date) => {
+                        const year = date.getFullYear();
+                        const month = String(date.getMonth() + 1).padStart(2, '0');
+                        const day = String(date.getDate()).padStart(2, '0');
+                        return `${year}-${month}-${day}`;
+                      };
+                      
+                      // URL 파라미터 업데이트
+                      const searchParams = new URLSearchParams(window.location.search);
+                      searchParams.set('startDate', formatLocalDate(dateEditModal.selectedStartDate));
+                      searchParams.set('endDate', formatLocalDate(dateEditModal.selectedEndDate));
+                      searchParams.set('days', daysDiff.toString());
+                      
+                      window.location.search = searchParams.toString();
+                    }
+                  }}
+                  disabled={!dateEditModal.selectedStartDate || !dateEditModal.selectedEndDate}
+                  className={`flex-1 py-2.5 px-4 border rounded-xl transition-all duration-200 font-medium ${
+                    dateEditModal.selectedStartDate && dateEditModal.selectedEndDate
+                      ? 'bg-[#3E68FF]/20 hover:bg-[#3E68FF]/30 border-[#3E68FF]/50 hover:border-[#3E68FF]/70 text-[#3E68FF] hover:text-[#6FA0E6] cursor-pointer'
+                      : 'bg-[#1F3C7A]/30 border-[#1F3C7A]/50 text-[#94A9C9] cursor-not-allowed'
+                  }`}
+                >
+                  적용하기
                 </button>
               </div>
             </div>

--- a/frontend/src/app/plan/[attractionId]/page.tsx
+++ b/frontend/src/app/plan/[attractionId]/page.tsx
@@ -145,9 +145,17 @@ export default function PlanCalendar({ params }: PlanCalendarProps) {
   const handleSelectComplete = () => {
     if (selectedDates.length === 0) return
     
+    // 로컬 시간 기준으로 YYYY-MM-DD 포맷팅 (UTC 변환 없이)
+    const formatLocalDate = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+    
     // 선택된 날짜들을 query parameter로 전달하며 세부 일정 페이지로 이동
-    const startDate = selectedDates[0].toISOString().split('T')[0]
-    const endDate = selectedDates[selectedDates.length - 1].toISOString().split('T')[0]
+    const startDate = formatLocalDate(selectedDates[0])
+    const endDate = formatLocalDate(selectedDates[selectedDates.length - 1])
     
     router.push(`/itinerary/${params.attractionId}?startDate=${startDate}&endDate=${endDate}&days=${selectedDates.length}`)
   }

--- a/frontend/src/app/plan/calendar/page.tsx
+++ b/frontend/src/app/plan/calendar/page.tsx
@@ -72,9 +72,17 @@ export default function PlanCalendar() {
   const handleSelectComplete = () => {
     if (selectedDates.length === 0) return
 
+    // 로컬 시간 기준으로 YYYY-MM-DD 포맷팅 (UTC 변환 없이)
+    const formatLocalDate = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+
     // 선택된 날짜들을 query parameter로 전달하며 세부 일정 페이지로 이동
-    const startDate = selectedDates[0].toISOString().split('T')[0]
-    const endDate = selectedDates[selectedDates.length - 1].toISOString().split('T')[0]
+    const startDate = formatLocalDate(selectedDates[0])
+    const endDate = formatLocalDate(selectedDates[selectedDates.length - 1])
 
     // 기존 itinerary 페이지를 활용, general을 attractionId로 사용
     router.push(`/itinerary/general?startDate=${startDate}&endDate=${endDate}&days=${selectedDates.length}`)

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -635,9 +635,33 @@ export default function ProfilePage() {
       .filter(place => place.isLocked)
       .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
     
-    // 날짜 차이 계산
-    const startDate = new Date(trip.start_date)
-    const endDate = new Date(trip.end_date)
+    // 안전한 날짜 생성 및 포맷팅 함수
+    const createSafeDate = (dateString: string) => {
+      if (!dateString) return null
+      if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+        const [year, month, day] = dateString.split('-').map(Number)
+        return new Date(year, month - 1, day)
+      }
+      const date = new Date(dateString)
+      return isNaN(date.getTime()) ? null : date
+    }
+    
+    const formatDateForURL = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+
+    // 날짜 처리
+    const startDate = createSafeDate(trip.start_date)
+    const endDate = createSafeDate(trip.end_date)
+    
+    if (!startDate || !endDate) {
+      console.error('Invalid date format:', trip.start_date, trip.end_date)
+      return
+    }
+    
     const daysDiff = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1
     
     // URL 파라미터 생성 (보기 모드)
@@ -645,8 +669,8 @@ export default function ProfilePage() {
       places: placeIds.join(','),
       dayNumbers: dayNumbers.join(','),
       sourceTables: sourceTables.join(','),
-      startDate: trip.start_date,
-      endDate: trip.end_date,
+      startDate: formatDateForURL(startDate),
+      endDate: formatDateForURL(endDate),
       days: daysDiff.toString(),
       baseAttraction: 'general',
       source: 'profile',
@@ -677,9 +701,33 @@ export default function ProfilePage() {
       .filter(place => place.isLocked)
       .map(place => `${place.table_name}_${place.id}_${place.dayNumber}`)
     
-    // 날짜 차이 계산
-    const startDate = new Date(trip.start_date)
-    const endDate = new Date(trip.end_date)
+    // 안전한 날짜 생성 및 포맷팅 함수 (동일한 로직)
+    const createSafeDate = (dateString: string) => {
+      if (!dateString) return null
+      if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+        const [year, month, day] = dateString.split('-').map(Number)
+        return new Date(year, month - 1, day)
+      }
+      const date = new Date(dateString)
+      return isNaN(date.getTime()) ? null : date
+    }
+    
+    const formatDateForURL = (date: Date) => {
+      const year = date.getFullYear()
+      const month = String(date.getMonth() + 1).padStart(2, '0')
+      const day = String(date.getDate()).padStart(2, '0')
+      return `${year}-${month}-${day}`
+    }
+
+    // 날짜 처리
+    const startDate = createSafeDate(trip.start_date)
+    const endDate = createSafeDate(trip.end_date)
+    
+    if (!startDate || !endDate) {
+      console.error('Invalid date format:', trip.start_date, trip.end_date)
+      return
+    }
+    
     const daysDiff = Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1
     
     // URL 파라미터 생성 (편집 모드)
@@ -687,8 +735,8 @@ export default function ProfilePage() {
       places: placeIds.join(','),
       dayNumbers: dayNumbers.join(','),
       sourceTables: sourceTables.join(','),
-      startDate: trip.start_date,
-      endDate: trip.end_date,
+      startDate: formatDateForURL(startDate),
+      endDate: formatDateForURL(endDate),
       days: daysDiff.toString(),
       baseAttraction: 'general',
       source: 'profile',
@@ -705,8 +753,27 @@ export default function ProfilePage() {
 
   // 날짜 포맷 함수
   const formatDateRange = (startDate: string, endDate: string) => {
-    const start = new Date(startDate)
-    const end = new Date(endDate)
+    // 안전한 날짜 생성 함수
+    const createSafeDate = (dateString: string) => {
+      if (!dateString) return null
+      
+      // YYYY-MM-DD 형식인 경우 로컬 시간으로 생성
+      if (/^\d{4}-\d{2}-\d{2}$/.test(dateString)) {
+        const [year, month, day] = dateString.split('-').map(Number)
+        return new Date(year, month - 1, day)
+      }
+      
+      // 다른 형식인 경우 기본 Date 생성자 사용
+      const date = new Date(dateString)
+      return isNaN(date.getTime()) ? null : date
+    }
+    
+    const start = createSafeDate(startDate)
+    const end = createSafeDate(endDate)
+    
+    if (!start || !end) {
+      return '날짜 정보 없음'
+    }
     
     const formatDate = (date: Date) => {
       const year = date.getFullYear()


### PR DESCRIPTION
# Pull Request - 

### 주요 변경 요약

1. **한국 로컬 시간 기준으로 날짜 생성 및 포맷**

   * 기존 `toISOString()`(UTC 기준) 대신, `createLocalDate`, `formatLocalDate` 유틸을 사용해 
   YYYY-MM-DD 문자열을 로컬 시간 기준으로 처리.
   * 일정 하루 밀림 현상 해결.

2. **일정 편집 기능 강화**

   * `map/page.tsx`에 **날짜 수정 모달** 추가 → 여행 시작일/종료일을 UI에서 직접 수정 가능.
   * 기간이 줄어들 경우(예: 3일 → 2일), 잘려나가는 일자의 일정은 **마지막 일차로 자동 이동**.
   * 일정 수정 후 DB 저장/새로고침 시에도 반영된 상태 유지하도록 개선.

3. **DB 반영 이슈 수정**

   * `lockedPlaces` 상태가 의도와 다르게 저장되던 문제 해결 (DB에 false로 덮어쓰기 방지).
   * `useEffect` 의존성 배열에 `lockedPlaces` 추가 → 저장 시 반영 누락되지 않도록 수정.

4. **UI 개선**

   * 날짜가 없는 일자(빈 일정)도 표시하고, 안내 메시지를 보여줌.
   * 각 일차의 장소 배열이 `null/undefined`일 경우 안전하게 처리 (`(groupedPlaces[day] || [])`).
   * 여행 기간 블록 클릭 시 모달 열리도록 UX 개선.
   * 일정 카드 hover 시 편집 아이콘 표시.

5. **Profile 및 Plan 페이지 개선**

   * 잘못된/불완전한 날짜 포맷(`YYYY-MM-DD` 외)도 안전하게 처리 (`createSafeDate`).
   * URL 파라미터에 날짜를 넣을 때도 UTC 대신 로컬 기준 포맷 사용.
