### PR TITLE
fix: 북마크 기능 db 테이블 수정 및 정보 불러오는 코드 수정

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -104,10 +104,7 @@ class SavedLocation(Base):
 
     id = Column(Integer, primary_key=True, index=True, autoincrement=True)
     user_id = Column(String, ForeignKey("users.user_id"), nullable=False)
-    name = Column(String, nullable=False)  # 장소명
-    address = Column(String, nullable=True)  # 주소
-    latitude = Column(String, nullable=True)  # 위도
-    longitude = Column(String, nullable=True)  # 경도
+    places = Column(Text, nullable=False)  # "table_name:table_id" 형식
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/routers/saved_locations.py
+++ b/backend/routers/saved_locations.py
@@ -23,14 +23,12 @@ async def create_saved_location(
 ):
     """새 저장된 장소를 생성합니다."""
     try:
-        # 중복 체크 (같은 사용자의 같은 이름과 좌표)
+        # 중복 체크 (같은 사용자의 같은 places)
         existing_location = (
             db.query(SavedLocation)
             .filter(
                 SavedLocation.user_id == current_user.user_id,
-                SavedLocation.name == location_data.name,
-                SavedLocation.latitude == location_data.latitude,
-                SavedLocation.longitude == location_data.longitude
+                SavedLocation.places == location_data.places
             )
             .first()
         )
@@ -44,17 +42,14 @@ async def create_saved_location(
         # 저장된 장소 생성
         db_location = SavedLocation(
             user_id=current_user.user_id,
-            name=location_data.name,
-            address=location_data.address,
-            latitude=location_data.latitude,
-            longitude=location_data.longitude
+            places=location_data.places
         )
         
         db.add(db_location)
         db.commit()
         db.refresh(db_location)
         
-        logger.info(f"저장된 장소 생성: {db_location.name} for user {current_user.user_id}")
+        logger.info(f"저장된 장소 생성: {db_location.places} for user {current_user.user_id}")
         return db_location
         
     except Exception as e:
@@ -152,15 +147,12 @@ async def update_saved_location(
             )
         
         # 장소 정보 업데이트
-        location.name = location_data.name
-        location.address = location_data.address
-        location.latitude = location_data.latitude
-        location.longitude = location_data.longitude
+        location.places = location_data.places
         
         db.commit()
         db.refresh(location)
         
-        logger.info(f"저장된 장소 수정: {location.name} for user {current_user.user_id}")
+        logger.info(f"저장된 장소 수정: {location.places} for user {current_user.user_id}")
         return location
         
     except Exception as e:
@@ -200,7 +192,7 @@ async def delete_saved_location(
         db.delete(location)
         db.commit()
         
-        logger.info(f"저장된 장소 삭제: {location.name} for user {current_user.user_id}")
+        logger.info(f"저장된 장소 삭제: {location.places} for user {current_user.user_id}")
         return {"message": "저장된 장소가 삭제되었습니다."}
         
     except Exception as e:
@@ -224,9 +216,7 @@ async def check_saved_location(
             db.query(SavedLocation)
             .filter(
                 SavedLocation.user_id == current_user.user_id,
-                SavedLocation.name == location_data.name,
-                SavedLocation.latitude == location_data.latitude,
-                SavedLocation.longitude == location_data.longitude
+                SavedLocation.places == location_data.places
             )
             .first()
         )

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -166,10 +166,7 @@ class UserActionLog(BaseModel):
 
 # Saved Location schemas
 class SavedLocationBase(BaseModel):
-    name: str
-    address: Optional[str] = None
-    latitude: Optional[str] = None
-    longitude: Optional[str] = None
+    places: str  # "table_name:table_id" 형식
 
 
 class SavedLocationCreate(SavedLocationBase):

--- a/frontend/src/app/attraction/[id]/page.tsx
+++ b/frontend/src/app/attraction/[id]/page.tsx
@@ -63,6 +63,22 @@ export default function AttractionDetail({ params }: AttractionDetailProps) {
     return localStorage.getItem('access_token')
   }
 
+  // URL ID에서 places 형식으로 변환하는 함수
+  const getPlacesFromId = (id: string): string => {
+    if (id && id.includes('_') && !id.includes('undefined')) {
+      // table_name_id 형식인 경우 (예: restaurants_6151)
+      const lastUnderscoreIndex = id.lastIndexOf('_')
+      const tableName = id.substring(0, lastUnderscoreIndex)
+      const attractionId = id.substring(lastUnderscoreIndex + 1)
+      
+      if (tableName && attractionId && tableName !== 'undefined' && attractionId !== 'undefined') {
+        return `${tableName}:${attractionId}`
+      }
+    }
+    // 기본값 또는 오류 시
+    return id
+  }
+
   // API에서 관광지 상세 정보 가져오기
   useEffect(() => {
     const fetchAttractionDetail = async () => {
@@ -128,10 +144,7 @@ export default function AttractionDetail({ params }: AttractionDetailProps) {
           'Authorization': `Bearer ${token}`
         },
         body: JSON.stringify({
-          name: attractionData.name,
-          address: attractionData.address,
-          latitude: attractionData.latitude?.toString(),
-          longitude: attractionData.longitude?.toString()
+          places: getPlacesFromId(params.id)
         })
       })
       
@@ -172,10 +185,7 @@ export default function AttractionDetail({ params }: AttractionDetailProps) {
             'Authorization': `Bearer ${token}`
           },
           body: JSON.stringify({
-            name: attraction.name,
-            address: attraction.address,
-            latitude: attraction.latitude?.toString(),
-            longitude: attraction.longitude?.toString()
+            places: getPlacesFromId(params.id)
           })
         })
         
@@ -213,10 +223,7 @@ export default function AttractionDetail({ params }: AttractionDetailProps) {
             'Authorization': `Bearer ${token}`
           },
           body: JSON.stringify({
-            name: attraction.name,
-            address: attraction.address,
-            latitude: attraction.latitude?.toString(),
-            longitude: attraction.longitude?.toString()
+            places: getPlacesFromId(params.id)
           })
         })
         

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -948,6 +948,19 @@ export default function ProfilePage() {
     setDeletingTripId(null)
   }
 
+  // 카테고리 한국어 변환 함수
+  const getCategoryName = (category: string): string => {
+    const categoryMap: { [key: string]: string } = {
+      nature: '자연',
+      restaurants: '맛집',
+      shopping: '쇼핑',
+      accommodation: '숙박',
+      humanities: '인문',
+      leisure_sports: '레저'
+    }
+    return categoryMap[category] || category
+  }
+
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -1197,26 +1210,34 @@ export default function ProfilePage() {
                           {location.address || '주소 정보 없음'}
                         </p>
                         
-                        {/* 카테고리와 평점 */}
-                        <div className="flex items-center space-x-2 mb-2">
-                          {location.category && (
-                            <span className="text-xs bg-blue-500/20 text-blue-400 px-2 py-1 rounded-full">
-                              {location.category}
-                            </span>
-                          )}
-                          {location.rating && (
-                            <div className="flex items-center">
-                              <svg className="w-3 h-3 text-yellow-400 mr-1" fill="currentColor" viewBox="0 0 20 20">
-                                <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                              </svg>
-                              <span className="text-yellow-400 text-xs font-medium">{location.rating}</span>
-                            </div>
-                          )}
+                        {/* 카테고리와 평점, 날짜 */}
+                        <div className="flex items-center justify-between mb-2">
+                          <div className="flex items-center space-x-2">
+                            {location.category && (
+                              <span className="text-xs bg-blue-500/20 text-blue-400 px-2 py-1 rounded-full">
+                                {getCategoryName(location.category)}
+                              </span>
+                            )}
+                            {location.rating && (
+                              <div className="flex items-center">
+                                <svg className="w-3 h-3 text-yellow-400 mr-1" fill="currentColor" viewBox="0 0 20 20">
+                                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+                                </svg>
+                                <span className="text-yellow-400 text-xs font-medium">{location.rating}</span>
+                              </div>
+                            )}
+                          </div>
+                          
+                          <p className="text-gray-400 text-xs">
+                            {(() => {
+                              const date = new Date(location.created_at)
+                              const year = date.getFullYear().toString().slice(-2)
+                              const month = String(date.getMonth() + 1).padStart(2, '0')
+                              const day = String(date.getDate()).padStart(2, '0')
+                              return `${year}.${month}.${day}에 저장`
+                            })()}
+                          </p>
                         </div>
-                        
-                        <p className="text-gray-400 text-xs">
-                          {new Date(location.created_at).toLocaleDateString('ko-KR')}에 저장됨
-                        </p>
                       </div>
                       
                       {/* 삭제 버튼 */}


### PR DESCRIPTION
## Pull Request - Saved Location(저장된 장소) 관련 기능을 기존 `name, address, latitude, longitude` 기반 저장 구조에서 **`places` 필드(`table_name:table_id` 포맷)** 기반으로 변경했습니다.
이를 통해 다양한 엔터티(예: attractions, restaurants 등)를 일관된 방식으로 북마크/저장할 수 있도록 개선했습니다.

---

## 주요 변경사항

### 백엔드 (`backend/`)

* **모델(`models.py`)**

  * `SavedLocation` 모델에서 `name, address, latitude, longitude` 컬럼 제거
  * 새로운 `places: Text` 필드 추가 (예: `"restaurants:6151"`)
* **스키마(`schemas.py`)**

  * `SavedLocationBase` 스키마에서 `name, address, latitude, longitude` 제거
  * `places: str` 필드만 유지
* **라우터(`saved_locations.py`)**

  * 생성/업데이트/삭제/중복체크 시 `places` 기준으로 동작하도록 수정
  * 로깅 메시지 역시 `name` → `places` 로 교체

---

### 프론트엔드 (`frontend/src/app/`)

* **Attraction 상세 페이지 (`attraction/[id]/page.tsx`)**

  * `params.id` → `places` 포맷 변환 함수(`getPlacesFromId`) 추가
  * 저장/북마크 API 호출 시 `places` 값만 전달하도록 수정

* **일정 빌더 (`itinerary/[attractionId]/page.tsx`)**

  * `savedLocations` 처리 시 `places` 필드 분리하여 `tableName`, `tableId` 추출
  * `places` 기반으로 원본 장소 데이터를 enrichment (실제 attraction 데이터 fetch)
  * `getPlacesFromPlace` 유틸 추가 → `sourceTable:id` 형태 변환
  * 북마크 토글/저장/삭제 시 `places` 값만 API로 전달

* **프로필 페이지 (`profile/page.tsx`)**

  * 저장된 장소를 `places`(`table_name:table_id`) 기준으로 attraction 데이터 재조회
  * enrichment 과정에서 DB 원본의 이름/주소 누락 시 attraction API 응답으로 보완
  * 잘못된 `places` 포맷은 로그로 출력 후 제외
