### PR TITLE
Feat/map gps

### DIFF
--- a/backend/routers/trips.py
+++ b/backend/routers/trips.py
@@ -36,9 +36,9 @@ def get_place_name(db: Session, table_name: str, place_id: str):
 def get_status_display(status: str):
     """여행 상태를 한국어로 변환"""
     status_map = {
-        'planned': '📋 예정됨',
-        'active': '🚩 진행중',
-        'completed': '✓ 완료됨'
+        'planned': '📋 준비중',
+        'active': '🗺️ 여행중',
+        'completed': '👣 발자취'
     }
     return status_map.get(status, status)
 

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1710,7 +1710,6 @@ export default function MapPage() {
                 gap: 2px;
                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
                 white-space: nowrap;
-                transform: translateX(-10px);
               ">
                 <!-- 색상 동그라미에 이모티콘 -->
                 <div style="

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -3264,9 +3264,9 @@ export default function MapPage() {
                             onDragLeave={handleDragLeave}
                             onDrop={(e) => handleDrop(e, index, day)}
                             className={`w-full transition-all duration-200 ${
-                              dragOverIndex?.day === day && dragOverIndex?.index === index && draggedItem 
-                                ? 'border-t-4 border-[#3E68FF] bg-[#3E68FF]/10 mb-2' 
-                                : ''
+                              dragOverIndex?.day === day && dragOverIndex?.index === index && draggedItem
+                                ? 'border-t-4 border-[#3E68FF] bg-[#3E68FF]/10 mb-2 h-4'
+                                : 'h-2'
                             }`}
                           />
                           
@@ -3695,9 +3695,9 @@ export default function MapPage() {
                         onDragLeave={handleDragLeave}
                         onDrop={(e) => handleDrop(e, (groupedPlaces[day] || []).length, day)}
                         className={`w-full transition-all duration-200 ${
-                          dragOverIndex?.day === day && dragOverIndex?.index === (groupedPlaces[day] || []).length && draggedItem 
-                            ? 'border-t-4 border-[#3E68FF] bg-[#3E68FF]/10 mt-2' 
-                            : ''
+                          dragOverIndex?.day === day && dragOverIndex?.index === (groupedPlaces[day] || []).length && draggedItem
+                            ? 'border-t-4 border-[#3E68FF] bg-[#3E68FF]/10 mt-2 h-4'
+                            : 'h-2'
                         }`}
                       />
                     </div>

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -2777,6 +2777,7 @@ export default function MapPage() {
           markers={mapMarkers}
           onMapLoad={handleMapLoad}
           selectedMarkerIdFromParent={selectedMarkerId}
+          source={sourceParam}
           onMarkerClick={(markerId, markerType, position) => {
             if (markerType === 'category') {
               // 카테고리 마커 클릭 시 바텀 시트에 상세정보 표시

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1058,7 +1058,25 @@ export default function ProfilePage() {
         
         return (
           <div className="space-y-4">
-            {trips.map((trip) => (
+            {trips
+              .sort((a, b) => {
+                const statusA = getTripStatus(a.start_date, a.end_date)
+                const statusB = getTripStatus(b.start_date, b.end_date)
+
+                // 상태별 우선순위: active(1) > planned(2) > completed(3)
+                const statusOrder = { active: 1, planned: 2, completed: 3 }
+
+                const orderA = statusOrder[statusA]
+                const orderB = statusOrder[statusB]
+
+                if (orderA !== orderB) {
+                  return orderA - orderB
+                }
+
+                // 같은 상태일 때는 시작 날짜 기준으로 정렬
+                return new Date(a.start_date).getTime() - new Date(b.start_date).getTime()
+              })
+              .map((trip) => (
               <div 
                 key={trip.id} 
                 className="bg-gray-800 p-4 rounded-2xl relative cursor-pointer hover:bg-gray-750 transition-colors"

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -5,6 +5,22 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useSession, signOut } from 'next-auth/react'
 
+// 여행 상태를 날짜 기준으로 계산하는 함수
+const getTripStatus = (startDate: string, endDate: string): 'planned' | 'active' | 'completed' => {
+  const today = new Date()
+  today.setHours(0, 0, 0, 0) // 시간 부분을 00:00:00으로 설정
+
+  const start = new Date(startDate)
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date(endDate)
+  end.setHours(23, 59, 59, 999) // 끝나는 날의 마지막 시간으로 설정
+
+  if (today < start) return 'planned'      // 준비중
+  if (today >= start && today <= end) return 'active'  // 여행중
+  return 'completed'                       // 발자취
+}
+
 
 interface TripPlace {
   table_name: string
@@ -1051,13 +1067,13 @@ export default function ProfilePage() {
                 {/* 상태 표시와 버튼들 - 오른쪽 상단 */}
                 <div className="absolute top-4 right-4 flex items-center space-x-2">
                   <span className={`px-2 py-1 rounded-full text-xs flex items-center text-white ${
-                    trip.status === 'active' ? 'bg-red-500' : 
-                    trip.status === 'completed' ? 'bg-gray-500' : 
+                    getTripStatus(trip.start_date, trip.end_date) === 'active' ? 'bg-red-500' :
+                    getTripStatus(trip.start_date, trip.end_date) === 'completed' ? 'bg-gray-500' :
                     'bg-green-500'
                   }`}>
-                    {trip.status === 'planned' && '📋 준비중'}
-                    {trip.status === 'active' && '🗺️ 여행중'}
-                    {trip.status === 'completed' && '👣 발자취'}
+                    {getTripStatus(trip.start_date, trip.end_date) === 'planned' && '📋 준비중'}
+                    {getTripStatus(trip.start_date, trip.end_date) === 'active' && '🗺️ 여행중'}
+                    {getTripStatus(trip.start_date, trip.end_date) === 'completed' && '👣 발자취'}
                   </span>
                   
                   {/* 휴지통 버튼 */}

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1055,9 +1055,9 @@ export default function ProfilePage() {
                     trip.status === 'completed' ? 'bg-gray-500' : 
                     'bg-green-500'
                   }`}>
-                    {trip.status === 'active' && '🚩 진행중'}
-                    {trip.status === 'completed' && '✓ 완료됨'}
-                    {trip.status === 'planned' && '📋 예정됨'}
+                    {trip.status === 'planned' && '📋 준비중'}
+                    {trip.status === 'active' && '🗺️ 여행중'}
+                    {trip.status === 'completed' && '👣 발자취'}
                   </span>
                   
                   {/* 휴지통 버튼 */}

--- a/frontend/src/components/GoogleMap.tsx
+++ b/frontend/src/components/GoogleMap.tsx
@@ -17,6 +17,7 @@ interface GoogleMapProps {
   onMapLoad?: (map: any) => void
   onMarkerClick?: (markerId: string, markerType: string, position?: { lat: number; lng: number }) => void
   selectedMarkerIdFromParent?: string | null
+  source?: string | null // GPS 활성화 여부를 결정하는 source 파라미터 추가
 }
 
 // 카테고리별 아이콘 매핑
@@ -56,12 +57,18 @@ const GoogleMapComponent: React.FC<GoogleMapProps> = memo(({
   markers = [],
   onMapLoad,
   onMarkerClick,
-  selectedMarkerIdFromParent = null
+  selectedMarkerIdFromParent = null,
+  source = null
 }) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const [map, setMap] = useState<any>(null)
   const [isLoaded, setIsLoaded] = useState(false)
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null)
+  const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null)
+  const [userLocationMarker, setUserLocationMarker] = useState<any>(null)
+  const [locationWatchId, setLocationWatchId] = useState<number | null>(null)
+  const [gpsMode, setGpsMode] = useState<'off' | 'location' | 'compass'>('off') // GPS 버튼 모드 상태
+  const [currentHeading, setCurrentHeading] = useState<number | null>(null) // 현재 방향 저장
   const itineraryMarkersRef = useRef<any[]>([])
   const categoryMarkersRef = useRef<any[]>([])
   const markerInstancesRef = useRef<Map<string, { marker: any, category: string }>>(new Map())
@@ -286,6 +293,172 @@ const GoogleMapComponent: React.FC<GoogleMapProps> = memo(({
     }
   }, [map, markers])
 
+  // GPS 모드별 위치 추적 (profile에서만 가능)
+  useEffect(() => {
+    const shouldEnableGPS = source === 'profile' && (gpsMode === 'location' || gpsMode === 'compass')
+
+    if (shouldEnableGPS && map && (window as any).google && 'geolocation' in navigator) {
+      // 위치 추적 시작
+      const watchId = navigator.geolocation.watchPosition(
+        (position) => {
+          const newLocation = {
+            lat: position.coords.latitude,
+            lng: position.coords.longitude
+          }
+
+          setUserLocation(newLocation)
+
+          // 기존 사용자 위치 마커 제거
+          if (userLocationMarker) {
+            userLocationMarker.setMap(null)
+          }
+
+          // 새 사용자 위치 마커 생성 (방향 표시 화살표)
+          const heading = position.coords.heading // 디바이스가 향하는 방향 (도 단위, 북쪽 기준)
+          setCurrentHeading(heading)
+
+          const locationMarker = new (window as any).google.maps.Marker({
+            position: newLocation,
+            map,
+            title: `현재 위치${heading !== null && heading !== undefined ? ` (방향: ${Math.round(heading)}°)` : ''}`,
+            icon: {
+              path: (window as any).google.maps.SymbolPath.FORWARD_CLOSED_ARROW, // 화살표 모양
+              scale: 8,
+              fillColor: '#4285F4', // 구글 블루
+              fillOpacity: 1,
+              strokeColor: '#ffffff',
+              strokeWeight: 2,
+              rotation: heading !== null && heading !== undefined ? heading : 0 // 방향이 있으면 적용, 없으면 북쪽(0도)
+            }
+          })
+
+          setUserLocationMarker(locationMarker)
+
+          // 모드별 처리
+          if (gpsMode === 'location') {
+            // 위치 모드: 지도 회전 없이 위치만 업데이트 (사용자가 지도를 움직일 수 있음)
+            // 지도 중심을 강제로 이동시키지 않음
+          } else if (gpsMode === 'compass') {
+            // 나침반 모드: 위치 중앙 고정 + 지도 회전
+            map.panTo(newLocation) // 위치를 중앙에 고정
+            if (heading !== null && heading !== undefined) {
+              map.setHeading(heading) // 지도를 디바이스 방향에 맞춰 회전
+            }
+          }
+        },
+        (error) => {
+          console.warn('위치 정보를 가져올 수 없습니다:', error)
+        },
+        {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 60000
+        }
+      )
+
+      setLocationWatchId(watchId)
+    } else {
+      // GPS 비활성화 - 기존 위치 추적 중지 및 마커 제거
+      if (locationWatchId !== null) {
+        navigator.geolocation.clearWatch(locationWatchId)
+        setLocationWatchId(null)
+      }
+
+      if (userLocationMarker) {
+        userLocationMarker.setMap(null)
+        setUserLocationMarker(null)
+      }
+
+      if (gpsMode === 'off') {
+        setUserLocation(null)
+      }
+    }
+
+    // 컴포넌트 언마운트 시 위치 추적 정리
+    return () => {
+      if (locationWatchId !== null) {
+        navigator.geolocation.clearWatch(locationWatchId)
+      }
+      if (userLocationMarker) {
+        userLocationMarker.setMap(null)
+      }
+    }
+  }, [map, source, gpsMode, userLocationMarker, locationWatchId])
+
+  // 지도 드래그 시 GPS 모드 해제
+  useEffect(() => {
+    if (!map) return
+
+    const dragListener = map.addListener('drag', () => {
+      if (gpsMode !== 'off') {
+        setGpsMode('off')
+        map.setHeading(0) // 지도 회전 초기화
+      }
+    })
+
+    return () => {
+      if (dragListener) {
+        dragListener.remove()
+      }
+    }
+  }, [map, gpsMode])
+
+  // GPS 버튼 클릭 핸들러 - 3단계 모드 (off → location → compass → off)
+  const handleGpsButtonClick = () => {
+    switch (gpsMode) {
+      case 'off':
+        // 첫 번째 클릭: 현재 위치로 이동
+        setGpsMode('location')
+        if (userLocation && map) {
+          map.panTo(userLocation)
+          map.setZoom(16)
+        } else if ('geolocation' in navigator && map) {
+          navigator.geolocation.getCurrentPosition(
+            (position) => {
+              const location = {
+                lat: position.coords.latitude,
+                lng: position.coords.longitude
+              }
+              map.panTo(location)
+              map.setZoom(16)
+            },
+            (error) => {
+              console.warn('위치 정보를 가져올 수 없습니다:', error)
+              alert('위치 정보를 가져올 수 없습니다. GPS를 활성화해주세요.')
+              setGpsMode('off')
+            },
+            {
+              enableHighAccuracy: true,
+              timeout: 10000,
+              maximumAge: 60000
+            }
+          )
+        }
+        break
+
+      case 'location':
+        // 두 번째 클릭: 나침반 모드 활성화
+        setGpsMode('compass')
+        if (userLocation && map) {
+          map.panTo(userLocation)
+          map.setZoom(16)
+          // 현재 방향이 있으면 지도 회전
+          if (currentHeading !== null && currentHeading !== undefined) {
+            map.setHeading(currentHeading)
+          }
+        }
+        break
+
+      case 'compass':
+        // 세 번째 클릭: 일반 모드로 복귀
+        setGpsMode('off')
+        if (map) {
+          map.setHeading(0) // 지도 회전 초기화 (북쪽)
+        }
+        break
+    }
+  }
+
   const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
   
   if (!apiKey || apiKey === '') {
@@ -301,12 +474,72 @@ const GoogleMapComponent: React.FC<GoogleMapProps> = memo(({
   }
 
   return (
-    <div className={className}>
+    <div className={`relative ${className}`}>
       <div
         ref={mapRef}
         style={{ width: '100%', height: '100%' }}
         className="rounded-lg"
       />
+
+      {/* GPS 버튼 - profile에서 온 경우에만 표시 */}
+      {source === 'profile' && (
+        <button
+          onClick={handleGpsButtonClick}
+          className={`absolute bottom-4 right-4 w-12 h-12 rounded-full shadow-lg flex items-center justify-center transition-all z-10 border ${
+            gpsMode === 'off'
+              ? 'bg-white border-gray-200 hover:bg-gray-50'
+              : gpsMode === 'location'
+              ? 'bg-blue-500 border-blue-600 text-white'
+              : 'bg-blue-600 border-blue-700 text-white animate-pulse'
+          }`}
+          title={
+            gpsMode === 'off'
+              ? '현재 위치로 이동'
+              : gpsMode === 'location'
+              ? '나침반 모드 활성화'
+              : '나침반 모드 (탭해서 해제)'
+          }
+        >
+          {gpsMode === 'compass' ? (
+            // 나침반 모드: 나침반 아이콘
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M7 12l3-3 3 3 4-4M8 21l4-4 4 4M3 4h18M4 4h16v12a1 1 0 01-1 1H5a1 1 0 01-1-1V4z"
+              />
+            </svg>
+          ) : (
+            // 기본/위치 모드: 위치 아이콘
+            <svg
+              className={`w-6 h-6 ${gpsMode === 'off' ? 'text-blue-500' : 'text-white'}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+          )}
+        </button>
+      )}
+
       {!isLoaded && (
         <div className="absolute inset-0 bg-gradient-to-br from-blue-900 via-purple-900 to-indigo-900 flex items-center justify-center rounded-lg">
           <div className="text-center text-white/70">


### PR DESCRIPTION
# Pull Requset - Profile 지도 GPS 기능 및 여행 상태 표시 개선
이번 PR에서는 **여행 상태 표시 개선**과 **프로필 페이지에서 Google Map GPS 기능 추가**를 구현했습니다. 
사용자의 여행 상태를 동적으로 표시하고, 프로필 페이지에서 GPS 기반 위치 확인과 지도 방향 제어가 가능하도록 개선했습니다.

---

## 주요 변경 사항

### 1. Backend (`trips.py`)

* `get_status_display` 함수의 상태 문자열 수정

  * `planned`, `active`, `completed` 상태 한글 번역 개선

  ```python
      'planned': '📋 준비중',
      'active': '🗺️ 여행중',
      'completed': '👣 발자취'
  ```

---

### 2. Frontend

#### (1) `profile/page.tsx`

* 여행 상태 계산 함수 `getTripStatus` 추가

  * 오늘 날짜 기준으로 `planned`, `active`, `completed` 상태 동적 반환
* 여행 목록 정렬 개선

  * 상태 순서: `active > planned > completed`
  * 같은 상태 내에서는 시작일 순으로 정렬
* 여행 카드의 상태 표시 동적 반영

  * 색상 및 텍스트가 상태에 따라 자동 변경

  ```tsx
  bg-red-500 -> active
  bg-green-500 -> planned
  bg-gray-500 -> completed
  ```

#### (2) `components/GoogleMap.tsx`

* **GPS 기능 추가**

  * `source` prop을 통해 GPS 모드 활성화 여부 결정 (`profile` 페이지에서만 동작)
  * GPS 모드 3단계: `off`, `location`, `compass`
  * 현재 위치 추적, 지도 중심 이동, 지도 방향 설정 가능
  * 사용자가 지도를 드래그하면 자동으로 GPS 모드 해제
* GPS 버튼 UI 추가

  * 모드에 따라 색상, 아이콘, 애니메이션 적용
  * 클릭 시 모드 순환: `off → location → compass → off`
