### PR TITLE
Feat/current map marker update

### DIFF
--- a/backend/routers/attractions.py
+++ b/backend/routers/attractions.py
@@ -171,19 +171,30 @@ async def get_nearby_attractions(db: Session, selected_places: List[dict], radiu
             search_tables = CATEGORY_TABLES
             logger.info("전체 카테고리에서 검색")
 
+        # 각 경유지마다 균등하게 할당 (최소 10개씩은 보장)
+        places_count = len(selected_places)
+        limit_per_place = max(10, limit // places_count)
+
+        logger.info(f"경유지별 할당: {places_count}개 경유지, 각각 최대 {limit_per_place}개씩")
+
         # 선택한 각 장소를 중심으로 검색
-        for selected_place in selected_places:
+        for place_index, selected_place in enumerate(selected_places):
             if not selected_place.get('latitude') or not selected_place.get('longitude'):
                 continue
-                
+
             center_lat = float(selected_place['latitude'])
             center_lng = float(selected_place['longitude'])
-            
+
             # 검색 범위 계산 (성능 최적화)
             bounds = get_approximate_bounds(center_lat, center_lng, radius_km)
-            
+
+            # 현재 경유지에서 찾은 장소 수 카운트
+            current_place_count = 0
+
             # 선택된 카테고리 테이블에서 검색
             for table_name, table_model in search_tables.items():
+                if current_place_count >= limit_per_place:
+                    break
                 try:
                     # 범위 기반 필터링으로 성능 최적화 - LIMIT 제거로 범위 내 모든 데이터 조회
                     query = db.query(table_model).filter(
@@ -195,38 +206,53 @@ async def get_nearby_attractions(db: Session, selected_places: List[dict], radiu
                     
                     attractions = query.all()
                     logger.info(f"Table {table_name}: found {len(attractions)} attractions in bounds")
-                    
+
+                    # 거리 계산하고 정렬해서 가까운 장소부터 처리
+                    attractions_with_distance = []
+                    for attraction in attractions:
+                        distance = calculate_distance(
+                            center_lat, center_lng,
+                            float(attraction.latitude), float(attraction.longitude)
+                        )
+                        if distance <= radius_km:
+                            attractions_with_distance.append((attraction, distance))
+
+                    # 거리순으로 정렬
+                    attractions_with_distance.sort(key=lambda x: x[1])
+
                 except Exception as table_error:
                     logger.error(f"Error querying table {table_name}: {str(table_error)}")
                     continue
                 
-                for attraction in attractions:
+                # 거리순으로 정렬된 장소들을 처리
+                for attraction, distance in attractions_with_distance:
+                    # 현재 경유지 할당량 체크
+                    if current_place_count >= limit_per_place:
+                        break
+
                     # 고유 ID 생성
                     unique_id = f"{table_name}_{attraction.id}"
-                    
+
                     # 이미 처리된 장소는 스킵
                     if unique_id in processed_ids:
                         continue
-                    
+
                     # 선택한 장소와 같은 장소는 제외
                     if unique_id == selected_place.get('id'):
                         continue
-                    
-                    # 거리 계산
-                    distance = calculate_distance(
-                        center_lat, center_lng,
-                        float(attraction.latitude), float(attraction.longitude)
-                    )
-                    
-                    # 지정된 반경 내에 있는 장소만 추가
-                    if distance <= radius_km:
-                        category = get_category_from_table(table_name)
-                        formatted_attraction = format_attraction_data(attraction, category, table_name)
-                        formatted_attraction['distance'] = round(distance, 2)  # 거리 정보 추가
-                        formatted_attraction['nearbyTo'] = selected_place.get('name', '선택한 장소')  # 어느 장소 근처인지
-                        
-                        nearby_attractions.append(formatted_attraction)
-                        processed_ids.add(unique_id)
+
+                    category = get_category_from_table(table_name)
+                    formatted_attraction = format_attraction_data(attraction, category, table_name)
+                    formatted_attraction['distance'] = round(distance, 2)  # 거리 정보 추가
+                    formatted_attraction['nearbyTo'] = selected_place.get('name', '선택한 장소')  # 어느 장소 근처인지
+
+                    nearby_attractions.append(formatted_attraction)
+                    processed_ids.add(unique_id)
+                    current_place_count += 1
+
+                    # 현재 경유지에서 할당량 달성시 중단
+                    if current_place_count >= limit_per_place:
+                        break
         
         # 거리 순으로 정렬
         nearby_attractions.sort(key=lambda x: x['distance'])

--- a/backend/routers/attractions.py
+++ b/backend/routers/attractions.py
@@ -166,8 +166,8 @@ async def get_nearby_attractions(db: Session, selected_places: List[dict], radiu
             center_lat = float(selected_place['latitude'])
             center_lng = float(selected_place['longitude'])
             
-            # 검색 범위 계산 (성능 최적화) - 5km로 확장
-            bounds = get_approximate_bounds(center_lat, center_lng, 5.0)
+            # 검색 범위 계산 (성능 최적화)
+            bounds = get_approximate_bounds(center_lat, center_lng, radius_km)
             
             # 모든 카테고리 테이블에서 검색
             for table_name, table_model in CATEGORY_TABLES.items():
@@ -205,8 +205,8 @@ async def get_nearby_attractions(db: Session, selected_places: List[dict], radiu
                         float(attraction.latitude), float(attraction.longitude)
                     )
                     
-                    # 5km 반경 내에 있는 장소만 추가
-                    if distance <= 5.0:
+                    # 지정된 반경 내에 있는 장소만 추가
+                    if distance <= radius_km:
                         category = get_category_from_table(table_name)
                         formatted_attraction = format_attraction_data(attraction, category, table_name)
                         formatted_attraction['distance'] = round(distance, 2)  # 거리 정보 추가

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -1347,7 +1347,7 @@ export default function MapPage() {
   // 상태 업데이트 함수
   const updateStatus = (message: string, type: 'loading' | 'success' | 'error') => {
     setRouteStatus({ message, type });
-    setTimeout(() => setRouteStatus(null), 3000);
+    setTimeout(() => setRouteStatus(null), 5000);
   };
 
   // 기존 경로 제거
@@ -2242,9 +2242,9 @@ export default function MapPage() {
     const distanceText = totalDistance > 0 ? `${(totalDistance / 1000).toFixed(1)}km` : '알 수 없음';
     const durationText = totalDuration > 0 ? `${Math.round(totalDuration / 60)}분` : '알 수 없음';
     
-    const routeTypeText = isOptimized ? '최적화된 경로!' : '기본 동선 표시 완료!';
+    const routeTypeText = isOptimized ? '최적화 경로' : '기본 동선';
     updateStatus(
-      `${routeTypeText} (${segments.length}개 구간) - 총 거리: ${distanceText}, 총 시간: ${durationText}`,
+      `${routeTypeText} (${segments.length}개 구간) - 총 거리: ${distanceText}, 총 시간: ${durationText}\n※ 현재 시간 기준의 예상치입니다.\n실제 여행 시 다시 확인하세요.`,
       'success'
     );
   };
@@ -2506,7 +2506,7 @@ export default function MapPage() {
       const optimized = optimizeRouteOrderWithConstraints(originCoords, destinationCoords, destinationNames, constraints);
       
 
-      updateStatus(`${dayNumber}일차 경로 최적화 완료! (${lockedCount}개 순서 고정) 예상 거리: ${optimized.totalDistance.toFixed(1)}km. 실제 경로를 계산 중...`, 'loading');
+      updateStatus(`${dayNumber}일차 경로 최적화 중.. (${lockedCount}개 순서 고정)\n예상 거리: ${optimized.totalDistance.toFixed(1)}km. 실제 경로를 계산 중...`, 'loading');
 
       // 최적화된 순서대로 장소 객체 재구성
       const optimizedPlaces = [firstPlace];
@@ -2738,7 +2738,7 @@ export default function MapPage() {
                 <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
             )}
-            <span className="text-sm font-medium">{routeStatus.message}</span>
+            <span className="text-sm font-medium whitespace-pre-line">{routeStatus.message}</span>
           </div>
         </div>
       )}

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -916,7 +916,12 @@ export default function MapPage() {
       }
 
       const data = await response.json()
-      const places = data.attractions || []
+      let places = data.attractions || []
+
+      // 카테고리 필터 적용 (프론트엔드에서)
+      if (categoryFilter) {
+        places = places.filter((place: AttractionData) => place.category === categoryFilter)
+      }
 
       // 검색 결과 로그
       console.log('Bounds 검색 결과:', {
@@ -2991,8 +2996,8 @@ export default function MapPage() {
         <div className="absolute top-36 left-1/2 transform -translate-x-1/2 z-50">
           <button
             onClick={() => {
-              // 현재 지도 bounds를 기준으로 전체 카테고리 재검색
-              fetchPlacesInBounds(null);
+              // 현재 지도 bounds를 기준으로 선택된 카테고리 재검색
+              fetchPlacesInBounds(selectedCategory);
               setMapHasMoved(false); // 재검색 후 이동 상태 초기화
             }}
             className="px-4 py-2 rounded-full text-sm font-medium transition-all duration-200 flex items-center space-x-2 backdrop-blur-sm bg-orange-600 hover:bg-orange-500 text-white shadow-lg"
@@ -3379,8 +3384,8 @@ export default function MapPage() {
                         clearRoute()
                         // 기존 카테고리 장소와 마커를 먼저 초기화
                         setCategoryPlaces([])
-                        // 현재 지도 bounds 기준으로 전체 카테고리 검색
-                        fetchPlacesInBounds(null)
+                        // 현재 지도 bounds 기준으로 선택된 카테고리 검색
+                        fetchPlacesInBounds(selectedCategory)
                       }}
                       className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors"
                     >

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -872,14 +872,20 @@ export default function MapPage() {
       const centerLat = (boundsData.min_lat + boundsData.max_lat) / 2
       const centerLng = (boundsData.min_lng + boundsData.max_lng) / 2
 
-      // bounds 크기에 따른 동적 반경 계산 (대각선 거리의 70%)
+      // 모바일 감지
+      const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)
+
+      // bounds 크기에 따른 동적 반경 계산
       const diagonalDistance = calculateDistance(
         boundsData.min_lat, boundsData.min_lng,
         boundsData.max_lat, boundsData.max_lng
       )
-      const searchRadius = Math.min(Math.max(diagonalDistance * 0.7, 1.0), 10.0) // 최소 1km, 최대 10km
 
-      console.log('계산된 검색 반경:', searchRadius.toFixed(2), 'km')
+      // 모바일에서는 더 작은 반경 사용 (실제 보이는 영역에 맞춤)
+      const radiusMultiplier = isMobile ? 0.5 : 0.7
+      const searchRadius = Math.min(Math.max(diagonalDistance * radiusMultiplier, 1.0), 10.0) // 최소 1km, 최대 10km
+
+      console.log('계산된 검색 반경:', searchRadius.toFixed(2), 'km', isMobile ? '(모바일)' : '(PC)')
 
       const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
       const url = `${API_BASE_URL}/api/v1/attractions/nearby?radius_km=${searchRadius.toFixed(2)}&limit=500`

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -681,7 +681,8 @@ export default function MapPage() {
       }
       
       const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
-      const url = `${API_BASE_URL}/api/v1/attractions/nearby?radius_km=5.0&limit=500`
+      const categoryParam = categoryFilter ? `&category=${encodeURIComponent(categoryFilter)}` : ''
+      const url = `${API_BASE_URL}/api/v1/attractions/nearby?radius_km=5.0&limit=500${categoryParam}`
       
       // 선택한 장소들의 정보를 준비
       const selectedPlacesData = selectedItineraryPlaces
@@ -726,12 +727,8 @@ export default function MapPage() {
       
       const data = await response.json()
       let places = data.attractions || []
-      
-      // 카테고리 필터 적용
-      if (categoryFilter) {
-        places = places.filter((place: AttractionData) => place.category === categoryFilter)
-      }
-      
+
+      // 백엔드에서 이미 카테고리 필터링된 결과가 옴
       setCategoryPlaces(places)
     } catch (error: any) {
       console.error('주변 장소 검색 실패:', error)
@@ -888,7 +885,8 @@ export default function MapPage() {
       console.log('계산된 검색 반경:', searchRadius.toFixed(2), 'km', isMobile ? '(모바일)' : '(PC)')
 
       const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
-      const url = `${API_BASE_URL}/api/v1/attractions/nearby?radius_km=${searchRadius.toFixed(2)}&limit=500`
+      const categoryParam = categoryFilter ? `&category=${encodeURIComponent(categoryFilter)}` : ''
+      const url = `${API_BASE_URL}/api/v1/attractions/nearby?radius_km=${searchRadius.toFixed(2)}&limit=500${categoryParam}`
 
       const centerPlaceData = [{
         id: 'map_center',
@@ -918,12 +916,7 @@ export default function MapPage() {
       const data = await response.json()
       let places = data.attractions || []
 
-      // 카테고리 필터 적용 (프론트엔드에서)
-      if (categoryFilter) {
-        places = places.filter((place: AttractionData) => place.category === categoryFilter)
-      }
-
-      // 검색 결과 로그
+      // 백엔드에서 이미 카테고리 필터링된 결과가 옴
       console.log('Bounds 검색 결과:', {
         totalPlaces: places.length,
         bounds: boundsData,

--- a/frontend/src/components/GoogleMap.tsx
+++ b/frontend/src/components/GoogleMap.tsx
@@ -18,6 +18,7 @@ interface GoogleMapProps {
   onMarkerClick?: (markerId: string, markerType: string, position?: { lat: number; lng: number }) => void
   selectedMarkerIdFromParent?: string | null
   source?: string | null // GPS 활성화 여부를 결정하는 source 파라미터 추가
+  disableAutoBounds?: boolean // 자동 bounds 조정 비활성화 옵션
 }
 
 // 카테고리별 아이콘 매핑
@@ -58,7 +59,8 @@ const GoogleMapComponent: React.FC<GoogleMapProps> = memo(({
   onMapLoad,
   onMarkerClick,
   selectedMarkerIdFromParent = null,
-  source = null
+  source = null,
+  disableAutoBounds = false
 }) => {
   const mapRef = useRef<HTMLDivElement>(null)
   const [map, setMap] = useState<any>(null)
@@ -284,14 +286,14 @@ const GoogleMapComponent: React.FC<GoogleMapProps> = memo(({
     }
   }, [selectedMarkerIdFromParent, selectedMarkerId])
 
-  // 지도 영역 조정 (모든 마커가 보이도록)
+  // 지도 영역 조정 (모든 마커가 보이도록) - disableAutoBounds가 false일 때만
   useEffect(() => {
-    if (map && markers.length > 0) {
+    if (map && markers.length > 0 && !disableAutoBounds) {
       const bounds = new (window as any).google.maps.LatLngBounds()
       markers.forEach(marker => bounds.extend(marker.position))
       map.fitBounds(bounds)
     }
-  }, [map, markers])
+  }, [map, markers, disableAutoBounds])
 
   // GPS 모드별 위치 추적 (profile에서만 가능)
   useEffect(() => {


### PR DESCRIPTION
## Pull Request - 카테고리 기반 주변 장소 검색 및 지도 재검색 기능 추가

### 백엔드 (`backend/routers/attractions.py`)

* `get_nearby_attractions` 함수에 `category` 파라미터 추가

  * 특정 카테고리만 필터링하여 검색 가능
  * `CATEGORY_TABLES` 중 지정된 카테고리 테이블만 탐색
* 반경(`radius_km`) 계산 로직 개선

  * 기존 고정 5km → 요청 파라미터 기반 동적 반경
* 각 기준 장소별 결과 개수 제한 (`limit_per_place`) 도입

  * 균등 분배 (최소 10개 보장)
* 거리 기반 정렬 로직 개선

  * DB 조회 후 실제 거리 계산 → 반경 내 필터링 → 정렬
* `/api/v1/attractions/nearby` 엔드포인트에 `category` 쿼리 파라미터 추가

---

### 프론트엔드 (`frontend/src/app/map/page.tsx`)

* 주변 장소 조회 시 `category` 파라미터 지원
* 지도 이동/줌 변경 시 "이 지역에서 다시 검색" 버튼 노출

  * 조건: 일정 줌 레벨 이상(13 이상), 지도 이동 발생, 일정 모드 아님
  * 버튼 클릭 시 현재 지도 bounds 기준으로 주변 장소 재검색
* 반경(`radius_km`) 동적 계산 로직 추가

  * 줌 레벨 및 디바이스(모바일/PC)에 따라 반경 자동 조절
* `updateStatus` 메시지 표시 시간 5초로 변경
* 루트 상태 메시지에 줄바꿈 지원 (`whitespace-pre-line`)