### PR TITLE
Dev

### DIFF
--- a/backend/routers/recommendations2.py
+++ b/backend/routers/recommendations2.py
@@ -5,6 +5,8 @@ from typing import List, Optional, Dict, Any
 import asyncio
 import logging
 from asyncio import Semaphore
+import hashlib
+import json
 
 # 통합된 임포트 (backend 환경에 맞게 수정)
 try:
@@ -16,12 +18,14 @@ try:
     from vectorization2 import get_engine, close_engine
     from auth_utils import get_current_user_optional
     from recommendation_config import EXPLORE_REGIONS, EXPLORE_CATEGORIES, config
+    from cache_utils import cache, cached  # Redis 캐싱 유틸리티 추가
 except ImportError:
     try:
         # 상대 임포트 시도
         from ..vectorization2 import get_engine, close_engine
         from ..auth_utils import get_current_user_optional
         from ..recommendation_config import EXPLORE_REGIONS, EXPLORE_CATEGORIES, config
+        from ..cache_utils import cache, cached  # Redis 캐싱 유틸리티 추가
     except ImportError:
         # 개발용 Mock
         async def get_engine():
@@ -33,6 +37,16 @@ except ImportError:
         EXPLORE_REGIONS = ["서울특별시", "부산광역시"]
         EXPLORE_CATEGORIES = ["restaurants", "accommodation"]
         config = None
+        
+        # Mock cache
+        class MockCache:
+            def get(self, key): return None
+            def set(self, key, value, expire=None): return True
+        cache = MockCache()
+        def cached(expire=300, key_prefix=""):
+            def decorator(func):
+                return func
+            return decorator
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +64,60 @@ REQUEST_SEMAPHORE = Semaphore(MAX_PARALLEL_REQUESTS)
 
 
 # ============================================================================
-# 🔧 안전한 추천 데이터 조회 유틸리티 함수들
+# 🔧 Redis 캐싱 유틸리티 함수들
+# ============================================================================
+
+def generate_cache_key(prefix: str, user_id: Optional[str], region: Optional[str], 
+                      category: Optional[str], limit: int, **kwargs) -> str:
+    """
+    캐시 키 생성 함수
+    """
+    # 사용자별로 다른 캐시를 사용 (개인화 추천)
+    user_part = f"user_{user_id}" if user_id else "anonymous"
+    
+    # 파라미터들을 정렬된 문자열로 변환
+    params = {
+        'region': region or 'all',
+        'category': category or 'all',
+        'limit': limit
+    }
+    params.update(kwargs)
+    
+    # 안정적인 해시 생성을 위해 정렬
+    param_str = "&".join([f"{k}={v}" for k, v in sorted(params.items())])
+    
+    # MD5 해시로 긴 키를 줄임
+    hash_obj = hashlib.md5(param_str.encode())
+    param_hash = hash_obj.hexdigest()[:8]
+    
+    return f"{prefix}:{user_part}:{param_hash}"
+
+def get_recommendations_cache(cache_key: str) -> Optional[List[Dict[str, Any]]]:
+    """캐시에서 추천 데이터 조회"""
+    try:
+        cached_data = cache.get(cache_key)
+        if cached_data:
+            logger.info(f"Cache hit: {cache_key}")
+            return cached_data
+        return None
+    except Exception as e:
+        logger.error(f"Cache get error: {e}")
+        return None
+
+def set_recommendations_cache(cache_key: str, data: List[Dict[str, Any]], expire: int = 900) -> bool:
+    """캐시에 추천 데이터 저장 (기본 15분)"""
+    try:
+        success = cache.set(cache_key, data, expire=expire)
+        if success:
+            logger.info(f"Cache set: {cache_key} (expire: {expire}s)")
+        return success
+    except Exception as e:
+        logger.error(f"Cache set error: {e}")
+        return False
+
+
+# ============================================================================
+# 🔧 안전한 추천 데이터 조회 유틸리티 함수들 (캐싱 적용)
 # ============================================================================
 
 async def fetch_recommendations_with_fallback(
@@ -61,8 +128,23 @@ async def fetch_recommendations_with_fallback(
     fast_mode: bool = False  # 메인 페이지용 고속 모드
 ) -> List[Dict[str, Any]]:
     """
-    안전한 추천 데이터 조회 (통합 엔진 사용)
+    안전한 추천 데이터 조회 (통합 엔진 사용) - Redis 캐싱 적용
     """
+    # 캐시 키 생성
+    cache_key = generate_cache_key(
+        prefix="rec_main",
+        user_id=user_id,
+        region=region,
+        category=category,
+        limit=limit,
+        fast_mode=fast_mode
+    )
+    
+    # 캐시에서 조회 시도
+    cached_result = get_recommendations_cache(cache_key)
+    if cached_result is not None:
+        return cached_result
+    
     async with REQUEST_SEMAPHORE:
         try:
             # 통합 엔진 인스턴스 획득
@@ -79,6 +161,12 @@ async def fetch_recommendations_with_fallback(
                 ),
                 timeout=RECOMMENDATION_TIMEOUT
             )
+            
+            # 결과가 있으면 캐시에 저장 (메인페이지는 5분, 일반은 15분)
+            if result:
+                expire_time = 300 if fast_mode else 900  # 5분 or 15분
+                set_recommendations_cache(cache_key, result, expire=expire_time)
+            
             return result if result else []
 
         except asyncio.TimeoutError:
@@ -149,12 +237,27 @@ async def get_main_personalized_feed(
     region: Optional[str] = Query(None, description="지역 필터 (선택사항)")
 ):
     """
-    메인 상단 'For You' 섹션 - 개인화 추천
+    메인 상단 'For You' 섹션 - 개인화 추천 (Redis 캐싱 적용)
     - 로그인: 개인화 추천 (지역/카테고리 무관, 균등 가중치 50:50)
     - 비로그인: 인기 추천 (bookmark_cnt 기준)
     """
     try:
         user_id = str(current_user.user_id) if current_user else None
+
+        # 전체 응답 캐싱을 위한 캐시 키 생성
+        response_cache_key = generate_cache_key(
+            prefix="main_personalized",
+            user_id=user_id,
+            region=region,
+            category=None,
+            limit=limit
+        )
+        
+        # 캐시된 응답 조회
+        cached_response = cache.get(response_cache_key)
+        if cached_response is not None:
+            logger.info(f"🚀 Main personalized feed cache hit: {response_cache_key}")
+            return cached_response
 
         # priority_tag 가져오기 (explore와 동일한 방식)
         user_priority_tag = "none"
@@ -248,11 +351,18 @@ async def get_main_personalized_feed(
             processed_rec['category'] = category_mapping.get(table_name, table_name)
             processed_recommendations.append(processed_rec)
 
-        return {
+        # 응답 데이터 구성
+        response_data = {
             "featured": processed_recommendations[0] if processed_recommendations else None,
             "feed": processed_recommendations[1:] if len(processed_recommendations) > 1 else [],
             "total_count": len(processed_recommendations)
         }
+        
+        # 결과를 캐시에 저장 (5분 캐싱)
+        cache.set(response_cache_key, response_data, expire=300)
+        logger.info(f"🚀 Main personalized feed cached: {response_cache_key}")
+        
+        return response_data
 
     except Exception as e:
         logger.error(f"Error in get_main_personalized_feed: {e}")
@@ -269,13 +379,33 @@ async def get_main_explore_feed(
     categories: Optional[List[str]] = Query(None, description="요청할 카테고리 목록 (미지정시 인기순)")
 ):
     """
-    메인 하단 '탐색' 섹션 - 동적 인기순 지역별/카테고리별 추천
+    메인 하단 '탐색' 섹션 - 동적 인기순 지역별/카테고리별 추천 (Redis 캐싱 적용)
     - 지역: 북마크 총합 기준 인기순
     - 카테고리: 북마크 총합 기준 인기순
     - 장소: bookmark_cnt 기준 인기순
     """
     try:
         user_id = str(current_user.user_id) if current_user else None
+
+        # 전체 응답 캐싱을 위한 캐시 키 생성
+        regions_str = ",".join(sorted(regions)) if regions else "default"
+        categories_str = ",".join(sorted(categories)) if categories else "default"
+        
+        explore_cache_key = generate_cache_key(
+            prefix="main_explore",
+            user_id=user_id,
+            region=regions_str,
+            category=categories_str,
+            limit=50,  # 기본 limit
+            regions_count=len(regions) if regions else 0,
+            categories_count=len(categories) if categories else 0
+        )
+        
+        # 캐시된 응답 조회
+        cached_response = cache.get(explore_cache_key)
+        if cached_response is not None:
+            logger.info(f"🚀 Main explore feed cache hit: {explore_cache_key}")
+            return cached_response
 
         # 동적 지역/카테고리 순서 결정 (하드코딩 제거)
         if not regions or not categories:
@@ -352,9 +482,9 @@ async def get_main_explore_feed(
             }
         }
 
-        # 🚀 Redis 캐시에 저장 (10분 TTL)
-        cache.set(cache_key, result, expire=600)
-        logger.info(f"💾 Cached explore feed with priority tag '{user_priority_tag}': {cache_key}")
+        # 🚀 응답을 새로운 캐시 키로 저장 (8분 TTL - 메인페이지용 최적화)
+        cache.set(explore_cache_key, result, expire=480)
+        logger.info(f"🚀 Main explore feed cached: {explore_cache_key}")
 
         return result
 
@@ -379,10 +509,26 @@ async def get_explore_section(
     offset: int = Query(0, ge=0, description="페이징 오프셋")
 ):
     """
-    특정 지역/카테고리 섹션 데이터 조회 (우선순위 태그 기반 필터링, 지연 로딩, 페이징 지원)
+    특정 지역/카테고리 섹션 데이터 조회 (우선순위 태그 기반 필터링, 지연 로딩, 페이징 지원) - Redis 캐싱 적용
     """
     try:
         user_id = str(current_user.user_id) if current_user else None
+
+        # 개별 섹션 캐시 키 생성
+        section_cache_key = generate_cache_key(
+            prefix="explore_section",
+            user_id=user_id,
+            region=region,
+            category=category,
+            limit=limit,
+            offset=offset
+        )
+        
+        # 캐시된 응답 조회
+        cached_section = cache.get(section_cache_key)
+        if cached_section is not None:
+            logger.info(f"🚀 Explore section cache hit: {section_cache_key}")
+            return cached_section
 
         logger.info(f"Getting section data: {region}/{category} for user: {user_id}")
 
@@ -460,7 +606,8 @@ async def get_explore_section(
         # 오프셋 적용
         paginated_recommendations = recommendations[offset:offset + limit]
 
-        return {
+        # 응답 데이터 구성
+        section_response = {
             "region": region,
             "category": target_category,  # 실제 사용된 카테고리 반환
             "original_category": category,  # 원래 요청된 카테고리
@@ -474,6 +621,12 @@ async def get_explore_section(
             "success": True,
             "message": f"Found {len(paginated_recommendations)} recommendations"
         }
+        
+        # 결과를 캐시에 저장 (개별 섹션은 15분 캐싱)
+        cache.set(section_cache_key, section_response, expire=900)
+        logger.info(f"🚀 Explore section cached: {section_cache_key}")
+        
+        return section_response
 
     except Exception as e:
         logger.error(f"Error in get_explore_section: {e}")
@@ -490,10 +643,44 @@ async def get_explore_section(
 @router.get("/health", response_model=dict)
 async def health_check():
     """
-    추천 시스템 헬스체크
+    추천 시스템 헬스체크 (캐시 상태 포함)
     """
     try:
-        # 간단한 추천 요청으로 시스템 상태 확인
+        # 캐시 상태 확인
+        cache_status = "healthy"
+        cache_info = {"cached_keys": 0}
+        try:
+            # 테스트 캐시 쓰기/읽기
+            test_key = "health_check_test"
+            test_value = {"status": "ok", "timestamp": asyncio.get_event_loop().time()}
+            cache.set(test_key, test_value, expire=60)
+            read_value = cache.get(test_key)
+            
+            if read_value and read_value.get("status") == "ok":
+                cache_status = "healthy"
+                # Redis 캐시 키 개수 확인
+                try:
+                    if hasattr(cache, 'redis'):
+                        rec_keys = len(cache.redis.keys("rec_*"))
+                        main_keys = len(cache.redis.keys("main_*"))
+                        explore_keys = len(cache.redis.keys("explore_*"))
+                        cache_info = {
+                            "rec_keys": rec_keys,
+                            "main_keys": main_keys,
+                            "explore_keys": explore_keys,
+                            "total_rec_cache": rec_keys + main_keys + explore_keys
+                        }
+                except Exception:
+                    cache_info["note"] = "키 개수 확인 불가"
+                    
+            else:
+                cache_status = "write/read error"
+        except Exception as e:
+            cache_status = f"error: {str(e)[:50]}"
+
+        # 간단한 추천 요청으로 시스템 상태 확인 (캐시 효과 확인)
+        import time
+        start_time = time.time()
         test_recommendations = await fetch_recommendations_with_fallback(
             user_id=None,
             region=None,
@@ -501,12 +688,18 @@ async def health_check():
             limit=1,
             fast_mode=True  # 헬스체크는 빠르게
         )
+        response_time = round((time.time() - start_time) * 1000, 1)  # ms
 
         return {
             "status": "healthy",
             "engine_responsive": True,
+            "cache_status": cache_status,
+            "cache_info": cache_info,
+            "test_response_time_ms": response_time,
+            "cache_working": response_time < 100,  # 100ms 이하면 캐시에서 응답
             "timestamp": asyncio.get_event_loop().time(),
-            "test_result": len(test_recommendations) > 0
+            "test_result": len(test_recommendations) > 0,
+            "recommendations_count": len(test_recommendations)
         }
 
     except Exception as e:
@@ -517,6 +710,21 @@ async def health_check():
             "error": str(e),
             "timestamp": asyncio.get_event_loop().time()
         }
+
+
+@router.delete("/cache/clear")
+async def clear_cache():
+    """추천 캐시 삭제"""
+    try:
+        cleared = 0
+        if hasattr(cache, 'redis'):
+            for pattern in ["rec_*", "main_*", "explore_*"]:
+                keys = cache.redis.keys(pattern)
+                if keys:
+                    cleared += cache.redis.delete(*keys)
+        return {"cleared_keys": cleared, "message": f"{cleared}개 캐시 삭제됨"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 # ============================================================================

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -245,12 +245,7 @@ export default function Home() {
         // console.log('🔄 처리된 데이터로 setCitySections 호출:', processedData.length, '개 섹션')
       }
 
-      console.log('🔥 setCitySections 호출:', {
-        finalDataLength: finalData.length,
-        totalAttractions: totalAttractions,
-        processedDataLength: processedData.length,
-        originalResultLength: result.data?.length || 0
-      })
+       // console.log('setCitySections 호출:', finalData.length, '개 섹션')
       setCitySections(finalData)
 
       // 사용 가능한 지역 추출 및 업데이트
@@ -260,8 +255,7 @@ export default function Home() {
 
       setAvailableRegions(regions)
     } catch (error) {
-      console.error('🚨 데이터 로드 오류:', error instanceof Error ? error.message : String(error))
-      console.log('🚨 오류로 인해 빈 배열 설정')
+       console.error('데이터 로드 오류:', error instanceof Error ? error.message : String(error))
       setCitySections([])
     } finally {
       setLoading(false)
@@ -858,14 +852,14 @@ function AttractionCard({
 }) {
   const categoryColor = getCategoryColor(attraction.category?.trim())
 
-  // 이미지 URL 및 카테고리 디버깅
-  console.log(`🖼️ AttractionCard - ${attraction.name}:`, {
-    imageUrl: attraction.imageUrl,
-    imageUrlType: typeof attraction.imageUrl,
-    imageUrlLength: attraction.imageUrl?.length,
-    category: attraction.category,
-    fullData: attraction
-  })
+  // // 이미지 URL 및 카테고리 디버깅
+  // console.log(`🖼️ AttractionCard - ${attraction.name}:`, {
+  //   imageUrl: attraction.imageUrl,
+  //   imageUrlType: typeof attraction.imageUrl,
+  //   imageUrlLength: attraction.imageUrl?.length,
+  //   category: attraction.category,
+  //   fullData: attraction
+  // })
 
   return (
     <figure
@@ -897,7 +891,7 @@ function AttractionCard({
                 target.style.opacity = '1';
                 const loadingIndicator = target.previousElementSibling as HTMLElement;
                 if (loadingIndicator) loadingIndicator.style.display = 'none';
-                console.log(`✅ 이미지 로드 성공: ${attraction.name} - ${attraction.imageUrl}`);
+                // console.log(`✅ 이미지 로드 성공: ${attraction.name} - ${attraction.imageUrl}`);
               }}
               onError={(e) => {
                 const target = e.target as HTMLImageElement;
@@ -1080,11 +1074,7 @@ function UnifiedRecommendationSection({
           "
           style={{ scrollBehavior: 'smooth' }}
         >
-          {/* 🎯 디버그: filteredAttractions 확인 */}
-          {(() => {
-            console.log('🎯 UnifiedRecommendationSection 데이터 체크:', filteredAttractions.length);
-            return null;
-          })()}
+           {/* 디버그 로그 제거됨 */}
           {filteredAttractions.length === 0 && (
             <div className="flex-shrink-0 p-4 bg-red-500/20 text-white rounded mx-4">
               ⚠️ 추천할 장소가 없습니다
@@ -1153,11 +1143,7 @@ function PopularRecommendationSection({
           "
           style={{ scrollBehavior: 'smooth' }}
         >
-          {/* 🎯 디버그: filteredAttractions 확인 */}
-          {(() => {
-            console.log('🎯 UnifiedRecommendationSection 데이터 체크:', filteredAttractions.length);
-            return null;
-          })()}
+           {/* 디버그 로그 제거됨 */}
           {filteredAttractions.length === 0 && (
             <div className="flex-shrink-0 p-4 bg-red-500/20 text-white rounded mx-4">
               ⚠️ 추천할 장소가 없습니다

--- a/frontend/src/lib/dummyData.ts
+++ b/frontend/src/lib/dummyData.ts
@@ -211,9 +211,7 @@ export const fetchRecommendations = async (
     const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE || '/api/proxy'
 
     // 인증 토큰 가져오기
-    console.log('🔍 토큰 가져오기 시작')
     const token = await getAuthToken()
-    console.log('🔍 토큰 가져오기 결과:', !!token)
 
     // 헤더 설정
     const headers: Record<string, string> = {
@@ -224,11 +222,6 @@ export const fetchRecommendations = async (
     // 토큰이 있으면 Authorization 헤더 추가
     if (token) {
       headers['Authorization'] = `Bearer ${token}`
-      console.log('🔐 JWT 토큰 포함하여 API 호출:', token.substring(0, 20) + '...')
-      console.log('🔍 실제 토큰 길이:', token.length)
-      console.log('🔍 토큰 전체:', token) // 디버깅용 - 나중에 제거
-    } else {
-      console.warn('⚠️ JWT 토큰이 없어 비로그인 상태로 API 호출')
     }
 
     // v2 추천 시스템 API 사용
@@ -238,7 +231,6 @@ export const fetchRecommendations = async (
     }
 
     const url = `${API_BASE_URL}/api/v2/recommendations/main-feed/personalized?${params.toString()}`
-    console.log('v2 추천 API 호출:', url)
 
     // 3초 타임아웃으로 빠른 실패 처리
     const timeoutPromise = new Promise((_, reject) =>
@@ -745,7 +737,7 @@ const fetchRegionCategorySection = async (
     // 🎯 개별 지역 섹션 API 사용 (우선순위 태그 필터링 적용됨)
     const url = `${API_BASE_URL}/api/v2/recommendations/explore/${encodeURIComponent(region)}/${category}?limit=${limit}`
 
-    console.log(`🔧 개별 섹션 API 호출: ${region}/${category}`)
+    // console.log(`개별 섹션 API 호출: ${region}/${category}`)
 
     const response = await fetch(url, { headers })
 
@@ -816,7 +808,7 @@ export const fetchAllRegionsAllCategories = async (
       availableCategories = ["restaurants", "accommodation", "nature", "shopping", "culture", "activity"]
     }
 
-    console.log(`🚀 개별 섹션 API 방식으로 데이터 로드: ${Math.min(maxRegions, availableRegions.length)}개 지역, ${availableCategories.length}개 카테고리`)
+    // console.log(`개별 섹션 API 방식으로 데이터 로드: ${Math.min(maxRegions, availableRegions.length)}개 지역, ${availableCategories.length}개 카테고리`)
 
     const sections: CitySection[] = []
     const targetRegions = availableRegions.slice(0, maxRegions)


### PR DESCRIPTION
추천(Recommendation) 서버에 Redis 기반 캐싱 계층을 도입하고(메인/탐색/섹션 단위), 헬스체크와 캐시 관리 API를 개선했습니다. 프론트엔드에서는 과도한 디버그 로그를 정리하여 개인정보(토큰) 노출 가능성을 제거했습니다.

⸻

변경 목적 / 배경
	•	추천 응답의 지연 시간을 줄이고 엔진 비용을 절감하기 위해 주요 API 응답(메인 개인화 피드, 탐색 피드, 섹션)을 Redis에 캐싱합니다.
	•	헬스체크에 캐시 상태/읽기·쓰기 검사를 추가해 운영 시 캐시 문제를 빠르게 감지하도록 합니다.
	•	대량 키 삭제 시 Redis에 부담을 줄이기 위해 캐시 삭제 로직을 정비할 필요가 있습니다.
	•	개발 중 남아있던 민감 로그(전체 토큰 출력 등)를 제거하여 보안 위험을 낮춥니다.

⸻

변경 사항 요약 (핵심)
	•	generate_cache_key 추가: 파라미터 정렬 -> MD5(8자리) 해시로 안정적인 캐시 키 생성
	•	get_recommendations_cache / set_recommendations_cache 추가: 캐시 접근/저장 래퍼
	•	fetch_recommendations_with_fallback에 캐시 조회/저장 로직 추가 (fast_mode에 따라 TTL 차등)
	•	get_main_personalized_feed, get_main_explore_feed, get_explore_section에 전체 응답/섹션 응답 캐시 적용
	•	헬스 체크(/health)에서 캐시 읽기/쓰기 테스트와 엔진 호출(빠른 모드)으로 상태 측정 추가, 반환값 확장
	•	캐시 전역 삭제 API(/cache/clear) 추가 — Redis가 제공되는 경우 패턴별 키 삭제
	•	개발 시 사용할 MockCache를 추가해 로컬에서도 동작하도록 보강
	•	프론트엔드
	•	frontend/src/app/page.tsx: 여러 디버그 콘솔 로그 정리 및 불필요한 주석 제거
	•	frontend/src/lib/dummyData.ts: 토큰 전부 로그 출력 제거, 불필요한 디버그 로그 삭제

⸻

변경 파일 (요약)
	•	backend/.../recommendations.py (핵심 변경: 캐시 & 헬스체크) — 약 40 변경(13 추가 / 27 삭제)
	•	frontend/src/app/page.tsx — 디버그 로그 정리
	•	frontend/src/lib/dummyData.ts — 디버그 로그 및 토큰 민감정보 로그 제거

(원본 diff에서 경로명이 일부 생략되어 있어 backend 파일은 recommendations 관련 라우터 파일로 표기했습니다.)

⸻

상세 변경 및 기술적 설명

1) 캐시 키 생성: generate_cache_key
	•	입력: prefix, user_id, region, category, limit, 기타 kwargs
	•	동작:
	•	user_id가 있으면 user_<id> 아니면 anonymous로 구분하여 사용자별 분리
	•	파라미터들을 정렬해 문자열화한 뒤 MD5로 해싱(앞 8글자) — 키 길이 제한 대비
	•	권장 보완:
	•	캐시 무효화를 위해 CACHE_VERSION 또는 코드 배포 버전을 키에 포함하는 것을 권장합니다.

2) 캐시 접근 래퍼: get_recommendations_cache / set_recommendations_cache
	•	목적: Redis와의 직렬화/예외처리 일관화
	•	현재 동작:
	•	cache.get(key) 반환값을 그대로 반환 (MockCache와 호환)
	•	권장 개선/주의:
	•	Redis에 저장 시 json.dumps로 직렬화하고 조회 시 json.loads로 역직렬화하는 방식 권장 (혹은 앱용 표준 serializer 사용).
	•	cache.get이 bytes를 반환하는 클라이언트일 경우 바로 반환하면 타입 문제가 발생할 수 있음 — wrapper에서 확실히 처리 필요.

3) 추천 조회: fetch_recommendations_with_fallback
	•	동작:
	•	요청 파라미터로 cache_key 생성 후 캐시 조회
	•	캐시 미스 시 REQUEST_SEMAPHORE로 동시성 제어 후 엔진에서 결과 조회
	•	fast_mode일 경우 TTL 300s(5분), 기본은 900s(15분)
	•	주의사항:
	•	REQUEST_SEMAPHORE가 동시성 병목을 만들 수 있으므로 적절한 한계 설정 필요(현재 값은 코드 상단에서 정의된 것으로 가정).
	•	캐시가 존재하면 캐시 직렬화 형식에 따라 바로 반환/변환 처리 필요.

4) 메인 개인화 피드: get_main_personalized_feed
	•	변경:
	•	전체 응답을 main_personalized 키로 캐시(5분 TTL)
	•	캐시 히트 시 바로 반환
	•	featured/feed로 나누어 응답 포맷 정리
	•	구현 포인트:
	•	비로그인 유저는 인기 추천 (bookmark 기준), 로그인 유저는 개인화(가중치 50:50) — 기존 의도 유지
	•	캐시에 저장되는 객체 구조는 API 응답과 동일하게 유지

5) 메인 탐색 피드: get_main_explore_feed
	•	변경:
	•	요청된 regions / categories 조합을 포함한 explore_cache_key 생성
	•	캐시 히트 시 바로 반환
	•	동적 지역/카테고리 결정은 엔진 호출 결과를 사용
	•	캐시 저장 (10분, 메인 최적화용 8분 등)
	•	잠재적 버그(발견 및 권고 수정):
	•	코드 중 cache.set(cache_key, result, expire=600)로 cache_key를 사용한 곳이 있으나, 해당 블록에서 생성한 키 변수명은 explore_cache_key입니다. (변수명 혼동 -> 잘못된 키에 캐시 저장 가능)
	•	수정 권장: cache.set(explore_cache_key, result, expire=600)로 일관성 유지.

6) 섹션 조회: get_explore_section
	•	변경:
	•	explore_section prefix로 세부 섹션 키 생성(페이징 offset 포함)
	•	캐시 히트 시 바로 반환
	•	결과를 섹션 단위로 15분 캐싱
	•	주의:
	•	페이징(오프셋)을 포함해 키를 생성하므로 동일 오프셋만 캐시히트. (캐시 전략이 맞는지 검토 필요 — 오프셋 넓은 범위는 캐시 낭비 가능)

7) 헬스 체크: /health
	•	변경:
	•	캐시에 테스트 쓰기/읽기 수행 후 상태 반영
	•	간단 추천(1개, fast_mode=True)으로 엔진 응답 시간 측정
	•	캐시 키 개수(유효할 경우) 수집: rec_*, main_*, explore_*
	•	반환에 cache_status, cache_info, test_response_time_ms, cache_working, test_result, recommendations_count 추가
	•	중요한 버그(발견):
	•	리턴 dict에 "test_result": len(test_recommendations) > 0가 두 번 들어있고, 첫 항목 끝에 콤마 누락 -> 파이썬 문법 오류 발생 가능.
	•	권장 수정 (즉시 적용 예시):

# 잘못된 부분 예시(현재 코드에 존재)
"test_result": len(test_recommendations) > 0
"test_result": len(test_recommendations) > 0,

# 제안 수정 (하나의 키만 사용, trailing comma 포함)
"test_result": len(test_recommendations) > 0,

	•	기타 개선 제안:
	•	cache_working 판정: response_time < 100만으로는 부정확. 캐시 히트 여부(cached_result 존재)도 함께 판단하도록 변경 권장.
	•	엔진 호출이 실패하면 헬스체크가 전체 실패로 보일 수 있으므로, 엔진 실패/타임아웃을 안전하게 삼중화(try/except) 해 서술하는 것이 좋음.

8) 캐시 삭제: /cache/clear
	•	현재:
	•	cache.redis.keys(pattern)로 키를 가져와 delete(*keys) 호출
	•	문제점:
	•	KEYS 명령은 Redis에 부하가 크므로 운영환경에서는 SCAN (또는 scan_iter) 사용 권장.
	•	API가 인증 없이 노출되어 있다면 거대한 삭제 공격에 취약 — 반드시 관리자 권한/인증 필요.
	•	권장 수정:

# 예: scan_iter 사용 예시
for pattern in ["rec_*", "main_*", "explore_*"]:
    for key in cache.redis.scan_iter(match=pattern):
        cache.redis.delete(key)

9) Mock / 개발 편의
	•	로컬 개발용 MockCache를 추가해 Redis 미존재 환경에서도 동작하도록 안전장치 구현 — 훌륭합니다.
	•	주의: MockCache의 set은 True를 반환하고 get은 그대로 객체를 반환하므로 직렬화 차이 지점에 대비 필요.

10) 프론트엔드 정리
	•	page.tsx: 불필요한 디버그 출력 제거, 주요 디버그만 남김
	•	dummyData.ts:
	•	JWT 전체 출력(민감)을 제거 — 보안상 필수 조치
	•	토큰 길이/존재 여부만 로그에 남김
	•	타임아웃/URL 로그 정리

⸻

운영(배포) 전 체크리스트
	•	cache_utils의 get/set가 expire 파라미터를 지원하는지 확인
	•	프로덕션 Redis 연결 정보(REDIS_URL, 인증 등) 환경 변수로 설정
	•	CACHE_VERSION (또는 유사 키 버전) 도입 검토 — 배포 시 캐시 무효화 용이
	•	/cache/clear 엔드포인트에 관리용 인증(예: API 키, 관리자 권한) 적용
	•	헬스체크의 engine_responsive 판단 로직 보완(엔진 타임아웃 감지)
	•	REQUEST_SEMAPHORE 값 검토(동시성 / QPS 대비)
	•	로그 수준(level) 및 민감 정보(토큰/유저 id) 노출 점검
	•	Redis 키 갯수/메모리 영향 모니터링(예: Prometheus export)

⸻

테스트 계획

단위 테스트
	•	generate_cache_key 입력별 예측 가능한 키 생성 테스트
	•	get_recommendations_cache/set_recommendations_cache 직렬화/역직렬화 테스트 (fakeredis 사용)
	•	fetch_recommendations_with_fallback :
	•	캐시 히트 시 엔진 호출 없이 결과 반환
	•	캐시 미스 시 엔진 호출 및 캐시 저장(적절한 TTL)
	•	get_main_personalized_feed, get_main_explore_feed, get_explore_section 캐시 히트/미스 동작 테스트

통합 테스트
	•	실제 Redis(fakeredis)로 기동해 전체 API 호출 시 캐시 동작 확인
	•	헬스체크가 캐시 쓰기/읽기와 엔진 호출 모두를 보고하는지 확인

수동 검증 (스테이징)
	•		1.	엔진 정상/엔진 다운(응답 지연) 상태에서 /health 응답 확인
	•		2.	동일 요청 반복 -> 두 번째 요청은 응답시간 단축(캐시 히트) 확인
	•		3.	/cache/clear 호출 후 캐시 키가 제거되는지 확인
	•		4.	민감 로그(토큰 값 전체)가 프론트엔드 콘솔/서버 로그에 남아있지 않은지 확인

⸻

보안 & 준수 점검
	•	민감 데이터 노출 금지: 프론트엔드에서 JWT 전체 로그 제거(완료). 서버 로그에서도 토큰/패스워드 등 민감 정보 로깅 금지 권장.
	•	관리 API 보안: /cache/clear는 관리자 인증(토큰/Role 기반)을 강제해야 함.
	•	캐시 데이터: 사용자별 캐시(user_<id>)를 사용하므로, 누락/레거시 키로 인한 타인 데이터 노출 위험은 낮지만 만약 캐시 키 패턴이 유추 가능하면 주의 필요.

⸻

성능 관련 제안
	•	TTL 정책(5분/8분/10분/15분)을 일관된 config 항목으로 옮겨 환경별로 튜닝 가능하게 만드는 것이 좋습니다.
	•	캐시 히트/미스 카운터와 응답 시간 히스토그램(Prometheus) 계측 도입 권장.
	•	대규모 탐색(모든 지역/카테고리) 결과는 precompute/배치 작업으로 보완 가능.

⸻

발견된 버그 및 즉시 적용 권장 패치

1) 헬스체크: 리턴 dict 중복/콤마 누락

-            "test_result": len(test_recommendations) > 0
-            "test_result": len(test_recommendations) > 0,
+            "test_result": len(test_recommendations) > 0,

2) get_main_explore_feed 내부 캐시 저장 시 변수 오타

-        cache.set(cache_key, result, expire=600)
-        logger.info(f"💾 Cached explore feed with priority tag '{user_priority_tag}': {cache_key}")
+        # 올바른 키 사용: explore_cache_key
+        cache.set(explore_cache_key, result, expire=600)
+        logger.info(f"💾 Cached explore feed with priority tag '{user_priority_tag}': {explore_cache_key}")

3) 캐시 직렬화/역직렬화 기본 처리 (권장)

def set_recommendations_cache(cache_key: str, data: List[Dict[str, Any]], expire: int = 900) -> bool:
    try:
        payload = json.dumps(data, ensure_ascii=False)
        success = cache.set(cache_key, payload, expire=expire)
        return success
    except Exception as e:
        logger.error(...)
        return False

def get_recommendations_cache(cache_key: str) -> Optional[List[Dict[str, Any]]]:
    try:
        cached_data = cache.get(cache_key)
        if not cached_data:
            return None
        # cache.get이 bytes일 수도 있으므로 텍스트로 변환
        if isinstance(cached_data, (bytes, bytearray)):
            cached_data = cached_data.decode()
        return json.loads(cached_data)
    except Exception as e:
        logger.error(...)
        return None

4) /cache/clear에서 KEYS -> SCAN으로 변경 권장 (예시)

if hasattr(cache, 'redis'):
    for pattern in ["rec_*", "main_*", "explore_*"]:
        for key in cache.redis.scan_iter(match=pattern):
            cache.redis.delete(key)
