### PR TITLE
Fix/day marker color fix

### DIFF
--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -2918,7 +2918,7 @@ export default function MapPage() {
               fetchPlacesInBounds(selectedCategory);
               setMapHasMoved(false); // 재검색 후 이동 상태 초기화
             }}
-            className="px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 flex items-center space-x-2 backdrop-blur-sm bg-orange-600 hover:bg-orange-500 text-white shadow-lg"
+            className="px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-200 flex items-center space-x-2 backdrop-blur-sm bg-[#EA580C] hover:bg-[#D97706] text-white shadow-lg"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -3307,8 +3307,7 @@ export default function MapPage() {
                         // 기존 카테고리 장소와 마커를 먼저 초기화
                         setCategoryPlaces([])
                         // 일정 장소 주변 5km, 모든 카테고리 검색 (카테고리 버튼과 동일한 방식)
-                        fetchNearbyPlaces(null)
-                      }}
+                        fetchNearbyPlaces(null)                      }}
                       className="px-3 py-1.5 bg-[#1F3C7A]/30 hover:bg-[#3E68FF]/30 rounded-full text-sm text-[#6FA0E6] hover:text-white transition-colors"
                     >
                       장소 찾기

--- a/frontend/src/app/map/page.tsx
+++ b/frontend/src/app/map/page.tsx
@@ -105,6 +105,21 @@ export default function MapPage() {
     : ''
   )
   const [isUpdatingTrip, setIsUpdatingTrip] = useState(false)
+
+  // 일차별 그라데이션 색상 계산 함수
+  const getDayColor = (dayNumber: number, totalDays: number) => {
+    // 1일차가 가장 진한 색, 마지막 일차가 가장 연한 색
+    const ratio = totalDays === 1 ? 0 : (dayNumber - 1) / (totalDays - 1);
+
+    // HSL로 그라데이션 계산 (진한 파랑 → 연한 파랑)
+    const hue = 227; // 파란색 계열
+    const saturation = 100;
+    const startLightness = 50; // 1일차: 더 진한 색상
+    const endLightness = 75;   // 마지막일차: 더 연한 색상
+
+    const lightness = Math.round(startLightness + ratio * (endLightness - startLightness));
+    return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+  }
   
   const [selectedItineraryPlaces, setSelectedItineraryPlaces] = useState<SelectedPlace[]>([])
   const [categoryPlaces, setCategoryPlaces] = useState<AttractionData[]>([])
@@ -1234,6 +1249,10 @@ export default function MapPage() {
   // 지도 마커 데이터 생성 - 일정 마커는 항상 유지
   const mapMarkers = useMemo(() => {
     const markers = []
+
+    // 총 일차 수 계산
+    const totalDays = selectedItineraryPlaces.length > 0 ?
+      Math.max(...selectedItineraryPlaces.map(p => p.dayNumber || 1)) : 1
     
     // 선택된 일정 장소들은 항상 표시 (모든 모드에서)
     if (selectedItineraryPlaces.length > 0) {
@@ -1243,7 +1262,9 @@ export default function MapPage() {
           position: { lat: place.latitude!, lng: place.longitude! },
           title: place.name,
           id: place.id,
-          type: 'itinerary' as const // 일정 마커 구분
+          type: 'itinerary' as const, // 일정 마커 구분
+          dayNumber: place.dayNumber, // 일차 정보 추가
+          totalDays: totalDays // 총 일차 수 추가
         }))
       markers.push(...itineraryMarkers)
     }
@@ -2875,7 +2896,7 @@ export default function MapPage() {
               }}
               className={`flex-shrink-0 px-3 py-2 rounded-full text-xs font-medium transition-all duration-200 flex items-center space-x-1 backdrop-blur-sm ${
                 selectedCategory === category.key
-                  ? 'bg-[#3E68FF] text-white shadow-lg'
+                  ? 'bg-[#EA580C] text-white shadow-lg'
                   : 'bg-black/30 text-gray-300 hover:text-white hover:bg-black/50'
               }`}
             >
@@ -3369,6 +3390,8 @@ export default function MapPage() {
                   allDays = Object.keys(groupedPlaces).map(Number).sort((a, b) => a - b);
                 }
 
+                const totalDays = Math.max(...allDays);
+
                 return allDays.map(day => (
                   <div key={day} className={`mb-6 rounded-2xl transition-all duration-300 ${
                     highlightedDay === day ? 'bg-[#3E68FF]/10 border-2 border-[#3E68FF]/30 p-4' : 'p-2'
@@ -3385,9 +3408,14 @@ export default function MapPage() {
                       }}
                     >
                       <div className="flex items-center">
-                        <div className={`rounded-full w-8 h-8 flex items-center justify-center mr-3 transition-all duration-200 ${
-                          highlightedDay === day ? 'bg-[#3E68FF] shadow-lg scale-110' : 'bg-[#3E68FF]'
-                        }`}>
+                        <div
+                          className={`rounded-full w-8 h-8 flex items-center justify-center mr-3 transition-all duration-200 ${
+                            highlightedDay === day ? 'shadow-lg scale-110' : ''
+                          }`}
+                          style={{
+                            backgroundColor: getDayColor(day, totalDays)
+                          }}
+                        >
                           <span className="text-white text-sm font-bold">{day}</span>
                         </div>
                         <h3 className={`text-lg font-semibold transition-colors duration-200 ${


### PR DESCRIPTION
##  Pull Request - 일차 및 마커 그라데이션 추가

### 1. **Day 기반 컬러 그라데이션 추가**

* `getDayColor(dayNumber, totalDays)` 함수 구현

  * HSL 기반으로 여행 **1일차 → 마지막 일차**까지 점차 밝아지는 색상 적용
  * `MapPage`와 `GoogleMap` 양쪽에서 재사용
* 마커와 일정 아이콘(숫자 배경)에 `dayNumber`, `totalDays` 전달 → 일차별 색상 반영

---

### 2. **마커 스타일 개선**

* 기존: 파란색(`[#3E68FF]`) / 빨간색(`[#FF6B6B]`) 
* 변경:

  * `일정(itinerary)` 마커 → **일차별 동적 색상(getDayColor)** 적용
  * 선택된 마커(scale 12)와 비선택 마커(scale 8) 모두 `dayColor` 반영
* category 마커(`createMarkerIcon`) → 기본 주황(`[#EA580C]`) 계열로 변경

---

### 3. **UI 색상 통일**

* 카테고리 버튼 색상 → `[#EA580C]` (주황 메인 컬러)로 교체

  * hover 시 `[#D97706]`
* 기존 블루 계열 버튼(`[#3E68FF]`) → 주황 계열로 변경하여 전체 톤 맞춤

---

### 4. **상세 수정 내용**

* `MapPage.tsx`

  * `getDayColor` 추가
  * `mapMarkers`에 `dayNumber`, `totalDays` 전달
  * 카테고리/플레이스 버튼 색상 변경 (블루 → 오렌지)
  * 일정 리스트(day indicator 원) → `getDayColor` 기반 동적 배경색 적용

* `GoogleMap.tsx`

  * `GoogleMapProps`에 `dayNumber`, `totalDays` 필드 추가
  * `getDayColor` 함수 추가
  * itinerary 마커 생성 및 선택/해제 시 `dayColor` 적용
  * `markerInstancesRef`에 day 정보 함께 저장
